### PR TITLE
Switch to SauceLabs for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     # Please get your own free key if you want to test yourself
     - BROWSERSTACK_USERNAME: dtktestaccount1
     - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
-	- SAUCE_USERNAME: dojo2-ts-ci
+    - SAUCE_USERNAME: dojo2-ts-ci
     - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     # Please get your own free key if you want to test yourself
     - BROWSERSTACK_USERNAME: dtktestaccount1
     - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
+	- SAUCE_USERNAME: dojo2-ts-ci
+    - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
 		"grunt-contrib-watch": "0.6.1",
 		"grunt-exec": "0.4.6",
 		"grunt-text-replace": "0.4.0",
-		"grunt-ts": "5.1.0",
+		"grunt-ts": "5.2.0",
 		"grunt-tslint": "2.5.0",
 		"tslint": "2.5.1",
 		"intern": "~3.0.0",
 		"remap-istanbul": "~0.3.0",
-		"typescript": "~1.6.0"
+		"typescript": "~1.7.3"
 	}
 }

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -19,21 +19,19 @@ export var capabilities = {
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
 export var environments = [
-	{ browserName: 'internet explorer', version: [ '9', '10', '11' ], platform: 'WINDOWS' },
-	{ browserName: 'edge', version: '12', platform: 'WINDOWS' },
-	{ browserName: 'firefox', platform: [ 'WINDOWS', 'MAC' ] },
-	{ browserName: 'chrome', platform: [ 'WINDOWS', 'MAC' ] }/*,
-	{ browserName: 'safari', version: '8', platform: 'MAC' },
-	{ browserName: 'iPad', platform: 'MAC' },
-	{ browserName: 'iPhone', platform: 'MAC' },
-	{ broswerName: 'Android', platform: 'ANDROID' }*/
+	{ browserName: 'internet explorer', version: [ '9.0', '10.0', '11.0' ], platform: 'Windows 7' },
+	{ browserName: 'microsoftedge', platform: 'Windows 10' },
+	{ browserName: 'firefox', platform: [ 'Windows 10', 'Windows 7', 'OS X 10.11' ] },
+	{ browserName: 'chrome', platform: [ 'Windows 10', 'Windows 7', 'OS X 10.11' ] },
+	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
+	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-export var maxConcurrency = 2;
+export var maxConcurrency = 4;
 
 // Name of the tunnel class to use for WebDriver tests
-export var tunnel = 'BrowserStackTunnel';
+export var tunnel = 'SauceLabsTunnel';
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
 // can be used here

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.6.2",
+	"version": "1.7.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",


### PR DESCRIPTION
Testing switching to SauceLabs for testing.

Adding Android 4.4 and Safari 9 as well to the test coverage.
