### PR TITLE
Modify factory to pass instance instead of binding as context

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -9,7 +9,7 @@ import {
 } from './aspect';
 
 /* A weakmap that will store initialization functions for compose constructors */
-const initFnMap = new WeakMap<Function, ComposeInitializationFunction<any>[]>();
+const initFnMap = new WeakMap<Function, ComposeInitializationFunction<any, any>[]>();
 
 /**
  * A helper funtion to return a function that is rebased
@@ -75,7 +75,7 @@ function cloneFactory(base?: any): any {
 			throw new SyntaxError('Factories cannot be called with "new".');
 		}
 		const instance = Object.create(factory.prototype);
-		initFnMap.get(factory).forEach(fn => fn.apply(instance, args));
+		initFnMap.get(factory).forEach(fn => fn(instance, args));
 		return instance;
 	}
 
@@ -124,8 +124,8 @@ export interface GenericClass<T> {
 	prototype: T;
 }
 
-export interface ComposeInitializationFunction<O> {
-	(options?: O): void;
+export interface ComposeInitializationFunction<O, T> {
+	(instance: T, options?: O): void;
 }
 
 /* Extension API */
@@ -343,18 +343,18 @@ export interface ComposeFactory<O, T> {
 }
 
 export interface Compose {
-	<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
-	<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P>): ComposeFactory<O & P, A>;
-	<O, A>(base: A, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
-	create<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
-	create<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P>): ComposeFactory<O & P, A>;
-	create<O, A>(base: A, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
+	<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
+	<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P, A>): ComposeFactory<O & P, A>;
+	<O, A>(base: A, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
+	create<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
+	create<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P, A>): ComposeFactory<O & P, A>;
+	create<O, A>(base: A, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
 }
 
-function create<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
-function create<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P>): ComposeFactory<O & P, A>;
-function create<O, A>(base: A, initFunction?: ComposeInitializationFunction<O>): ComposeFactory<O, A>;
-function create<O>(base: any, initFunction?: ComposeInitializationFunction<O>): any {
+function create<O, A>(base: GenericClass<A>, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
+function create<O, A, P>(base: ComposeFactory<O, A>, initFunction?: ComposeInitializationFunction<P, A>): ComposeFactory<O & P, A>;
+function create<O, A>(base: A, initFunction?: ComposeInitializationFunction<O, A>): ComposeFactory<O, A>;
+function create<O>(base: any, initFunction?: ComposeInitializationFunction<O, any>): any {
 	const factory = cloneFactory();
 	if (initFunction) {
 		initFnMap.get(factory).push(initFunction);

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -79,8 +79,8 @@ registerSuite({
 				}
 			}
 
-			function initFoo() {
-				this.foo();
+			function initFoo(instance: Foo) {
+				instance.foo();
 			}
 
 			const createFoo = compose(Foo, initFoo);
@@ -91,9 +91,9 @@ registerSuite({
 		'initialise function with prototype': function () {
 			let counter = 0;
 
-			function initFoo() {
-				this.foo();
-				this.bar = 'foo';
+			function initFoo(instance: {foo: () => any, bar: string}) {
+				instance.foo();
+				instance.bar = 'foo';
 			}
 
 			const createFoo = compose({
@@ -122,10 +122,10 @@ registerSuite({
 				bar: <string> undefined
 			};
 
-			function initFoo(options?: any) {
+			function initFoo(instance: {foo: () => any, bar: string}, options?: any) {
 				constructOptions = options;
-				this.foo();
-				this.bar = 'foo';
+				instance.foo();
+				instance.bar = 'foo';
 			}
 
 			const createFoo = compose(<GenericClass< { foo(): void; bar: string; } >> <any> Foo, initFoo);
@@ -334,20 +334,20 @@ registerSuite({
 			const foobar = createFooBar();
 
 			assert.strictEqual(foobar.foo, 'foo', 'instance contains foo');
-			assert.strictEqual(foobar.bar, 2, 'instance contains foo');
+			assert.strictEqual(foobar.bar, 2, 'instance contains bar');
 		},
 		'concat init functions'() {
 			const createBar = compose({
 				bar: 2
-			}, function() {
-				this.bar = 3;
+			}, function(instance) {
+				instance.bar = 3;
 			});
 
 			const createFooBar = compose({
 				foo: 'foo'
-			}, function() {
-				this.foo = 'bar';
-				assert.strictEqual(this.bar, 3, 'instance constains foo');
+			}, function(instance: {foo: string, bar: number}) {
+				instance.foo = 'bar';
+				assert.strictEqual(instance.bar, 3, 'instance contains bar');
 			}).mixin(createBar);
 
 			const foobar = createFooBar();


### PR DESCRIPTION
In the discussion of the pros and cons of a factory pattern vs using a constructor, one potential advantage of using a factory was that the context in which it is executed can be changed. As the code exists now, this is impossible, because the wrapping factory function [binds all of the initializing functions to the context of the created instance](https://github.com/dojo/compose/blob/3b1606ee14121dbad8eb03470c0b478bfdc25968/src/compose.ts#L78). A possible change, that would still allow the initialization functions to access the instance but would also allow them to operate in their original context, would be to pass the instance as a variable to the function. 

This idea isn't completely original, [stampit](https://github.com/stampit-org/stampit/blob/master/docs/API.md#stampinitarg1-arg2-arg3) does something similar.
