### PR TITLE
Correct proper ordering of the init functions

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -99,13 +99,15 @@ function cloneFactory(base?: any): any {
  * @param source The ComposeFactory to copy the init functions from
  */
 function concatInitFn<O, T, P, S>(target: ComposeFactory<O, T>, source: ComposeFactory<P, S>): void {
-	const initFn = initFnMap.get(target);
+	const sourceInitFns = initFnMap.get(source);
+
 	/* making sure only unique functions get added */
-	initFnMap.get(source).forEach((item) => {
-		if (initFn.indexOf(item) < 0) {
-			initFn.unshift(item);
-		}
+	const targetInitFns = initFnMap.get(target).filter((fn) => {
+		return sourceInitFns.indexOf(fn) < 0;
 	});
+
+	/* now prepend the source init functions to the unique init functions for the target */
+	initFnMap.set(target, sourceInitFns.concat(targetInitFns));
 }
 
 /**

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -167,6 +167,47 @@ registerSuite({
 			assert.strictEqual(foo.bar, 'foo', 'bar is initialised to foo');
 			assert.instanceOf(foo, createFoo, 'foo is an instanceOf Foo');
 		},
+		'initialize function ordering'() {
+			/* The goal here is two fold, mixed in init functions should be called
+			 * first, in order for them to have the proper effect on the instance
+			 * as well as duplicate functions should be eliminated (diamond problem)
+			 */
+
+			const callstack: string[] = [];
+
+			const createFoo = compose({
+				foo: 'bar'
+			}, () => {
+				callstack.push('foo');
+			});
+
+			const createFooBar = compose({
+					bar: 1
+				}, () => {
+					callstack.push('foobar');
+				})
+				.mixin(createFoo);
+
+			const createFooBaz = compose({
+					baz: true
+				}, () => {
+					callstack.push('foobaz');
+				})
+				.mixin(createFoo);
+
+			const createFooBarBazQat = compose({
+					qat: /qat/
+				}, () => {
+					callstack.push('foobarbazqat');
+				})
+				.mixin(createFooBar)
+				.mixin(createFooBaz);
+
+			const foobarbazqat = createFooBarBazQat();
+
+			assert.deepEqual(callstack, [ 'foo', 'foobaz', 'foobar', 'foobarbazqat' ],
+				'Init functions should be called in proper order and duplicates eliminated');
+		},
 		'.create()': function () {
 			let counter = 0;
 


### PR DESCRIPTION
Previously, init functions were not being properly ordered when being mixed into a factory.  This patch fixes that and keeps proper ordering even when there is a diamond mixin problem (B and C mixin A and D mixes in B and C).
