### PR TITLE
Expand Evented.on() API

### DIFF
--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -40,11 +40,13 @@ export interface EventedCallback<E extends EventObject> {
  */
 export type EventedListener<E extends TargettedEventObject> = EventedCallback<E> | Actionable<E>;
 
+export type EventeListenerOrArray<E extends TargettedEventObject> = EventedListener<E> | EventedListener<E>[];
+
 /**
  * A map of listeners where the key is the event `type`
  */
 export interface EventedListenersMap {
-	[type: string]: EventedListener<TargettedEventObject>;
+	[type: string]: EventeListenerOrArray<TargettedEventObject>;
 }
 
 /**
@@ -75,10 +77,18 @@ export interface EventedMixin {
 	 * Attach a `listener` to a particular event `type`.
 	 *
 	 * @param type The event to attach the listener to
-	 * @param listener Either a function which takes an emitted `event` object, or something that is `Actionable`
+	 * @param listener Either a function which takes an emitted `event` object, something that is `Actionable`,
+	 *                 or an array of of such listeners.
 	 * @returns A handle which can be used to remove the listener
 	 */
-	on(type: string, listener: EventedListener<TargettedEventObject>): Handle;
+	on(type: string, listener: EventeListenerOrArray<TargettedEventObject>): Handle;
+	/**
+	 * Attach a `listener` to a particular event `type`.
+	 *
+	 * @param type The event to attach the listener to
+	 * @param listeners An object which contains key value pairs of event types and listeners.
+	 */
+	on(listeners: EventedListenersMap): Handle;
 }
 
 export type Evented = EventedMixin & Destroyable;
@@ -119,7 +129,7 @@ const createEvented: EventedFactory = compose<EventedMixin, EventedOptions>({
 				method.call(this, event);
 			}
 		},
-		on(type: string, listener: EventedListener<Event>): Handle {
+		on(...args: any[]): Handle {
 			return on(listenersMap.get(this), type, resolveListener(listener));
 		}
 	})

--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -156,8 +156,7 @@ const createEvented: EventedFactory = compose<EventedMixin, EventedOptions>({
 				}
 			}
 			else if (args.length === 1) { /* overload: on(listners) */
-				let listenerMapArg: EventedListenersMap;
-				[ listenerMapArg ] = args;
+				const listenerMapArg: EventedListenersMap = args[0];
 				const handles = Object.keys(listenerMapArg).map((type) => evented.on(type, listenerMapArg[type]));
 				return handlesArraytoHandle(handles);
 			}

--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -155,7 +155,7 @@ const createEvented: EventedFactory = compose<EventedMixin, EventedOptions>({
 					return on(listenerMap, type, resolveListener(listeners));
 				}
 			}
-			else if (args.length === 1) { /* overload: on(listners) */
+			else if (args.length === 1) { /* overload: on(listeners) */
 				const listenerMapArg: EventedListenersMap = args[0];
 				const handles = Object.keys(listenerMapArg).map((type) => evented.on(type, listenerMapArg[type]));
 				return handlesArraytoHandle(handles);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
 		"./tests/**/*.ts"
 	],
 	"files": [
-		"./typings/extras.d.ts",
 		"./typings/index.d.ts",
 		"./src/aspect.ts",
 		"./src/compose.ts",


### PR DESCRIPTION
This PR add functionality to `Evented.on()` so it can take several different signatures.

For example:

``` typescript
import createEvented from 'dojo-compose/mixins/createEvented';

const evented = createEvented();
evented.on('foo', listener1); /* Existing */
evented.on('foo', [ listener1, listener2 ]); /* New, supply an array of listeners */
evented.on({
  foo(evt) {
    /* handle evt */
  }
}); /* New, supply a object literal map of listeners */
evented.on({
  foo: [ listener1, listener2 ]
}); /* New, combine a map and an array of listeners */
```

The handles that are returned will disconnect all the listeners supplied.

Resolves #33
