### PR TITLE
Handle non-undefined IDs in Stateful better

### DIFF
--- a/src/mixins/createStateful.ts
+++ b/src/mixins/createStateful.ts
@@ -225,7 +225,7 @@ const createStateful: StatefulFactory = compose<StatefulMixin<State>, StatefulOp
 			});
 			if (options) {
 				const { id, stateFrom } = options;
-				if (id && stateFrom) {
+				if (typeof id !== 'undefined' && stateFrom) {
 					instance.own(instance.observeState(id, stateFrom));
 				}
 				else if (stateFrom) {

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -3,7 +3,7 @@ export * from './intern';
 export const environments = [
 	{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
 	{ browserName: 'microsoftedge', platform: 'Windows 10' },
-	{ browserName: 'firefox', platform: 'Windows 10' },
+	{ browserName: 'firefox', version: '43', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
 	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' },

--- a/tests/unit/mixins/createStateful.ts
+++ b/tests/unit/mixins/createStateful.ts
@@ -42,6 +42,33 @@ registerSuite({
 			assert.strictEqual(called, 1);
 			assert.deepEqual(stateful.state, { foo: 'bar' });
 		},
+		'with id of 0'() {
+			/* while the interface specifies a string for an ID, real world usage may very well pass
+			 * a numeric ID which will eventually get coerced into a string, therefore the number of
+			 * 0 should be halnded gracefully */
+			let called = 0;
+			const observer = {
+				observe(id: string): Observable<State> {
+					called++;
+					return new Observable(function subscribe(observer: Observer<State>) {
+						observer.next({ foo: 'bar' });
+						observer.complete();
+					});
+				},
+				patch(value: any, options?: { id?: string }): Promise<State> {
+					assert.strictEqual(options.id, 0);
+					return Promise.resolve(value);
+				}
+			};
+
+			const stateful = createStateful<{ foo?: string; }>({
+				id: <any> 0,
+				stateFrom: observer
+			});
+
+			assert.strictEqual(called, 1);
+			assert.deepEqual(stateful.state, { foo: 'bar' });
+		},
 		'with only stateForm throws'() {
 			const observer = {
 				observe(id: string): Observable<State> {


### PR DESCRIPTION
**Type:** bug

**Description:** 

Handles non-`undefined` values during construction of `Stateful` better.

Previously, you could pass an ID that was falsey and the constructor function would throw.  While
the `id` for deriving the state is typed as a `string` in real world application an ID of `0` might be passed
upstream and `Stateful` shouldn't "worry" about this and simple pass it on to the observed state
interfaces.

**Related Issue:** #38

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
