### PR TITLE
Always 'clone' the advice dispatcher

### DIFF
--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,3 +1,4 @@
+import {  } from 'dojo-core/lang';
 import WeakMap from 'dojo-core/WeakMap';
 
 export interface AdvisingFunction extends Function {
@@ -22,6 +23,7 @@ export interface BeforeAdvice {
 	/**
 	 * Advice which is applied *before*, receiving the original arguments, if the advising function returns
 	 * a value, it is passed further along taking the place of the original arguments.
+	 *
 	 * @param args The arguments the method was called with
 	 */
 	(...args: any[]): any[] | void;
@@ -65,49 +67,67 @@ export interface GenericFunction<T> {
 
 /**
  * Returns the dispatcher function for a given joinPoint (method/function)
+ *
  * @param joinPoint The function that is to be advised
  */
 function getDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): F {
 
 	function dispatcher(...args: any[]): T {
-		const adviceMap = dispatchAdviceMap.get(dispatcher);
-		if (adviceMap.before) {
-			args = adviceMap.before.reduce((previousArgs, advice) => {
+		const { before, after, joinPoint } = dispatchAdviceMap.get(dispatcher);
+		if (before) {
+			args = before.reduce((previousArgs, advice) => {
 				const currentArgs = advice.apply(this, previousArgs);
-				return currentArgs ? currentArgs : previousArgs;
+				return currentArgs || previousArgs;
 			}, args);
 		}
-		let result = adviceMap.joinPoint.apply(this, args);
-		if (adviceMap.after) {
-			result = adviceMap.after.reduce((previousResult, advice) => {
+		let result = joinPoint.apply(this, args);
+		if (after) {
+			result = after.reduce((previousResult, advice) => {
 				return advice.apply(this, [ previousResult ].concat(args));
 			}, result);
 		}
 		return result;
 	}
 
-	dispatchAdviceMap.set(dispatcher, {
-		joinPoint: joinPoint
-	});
+	/* We want to "clone" the advice that has been applied already, if this
+	 * joinPoint is already advised */
+	if (dispatchAdviceMap.has(joinPoint)) {
+		const adviceMap = dispatchAdviceMap.get(joinPoint);
+		let { before, after } = adviceMap;
+		if (before) {
+			before = before.slice(0);
+		}
+		if (after) {
+			after = after.slice(0);
+		}
+		dispatchAdviceMap.set(dispatcher, {
+			joinPoint: adviceMap.joinPoint,
+			before,
+			after
+		});
+	}
+	/* Otherwise, this is a new joinPoint, so we will create the advice map afresh */
+	else {
+		dispatchAdviceMap.set(dispatcher, { joinPoint });
+	}
 
 	return dispatcher as F;
 }
 
 /**
  * Advise a join point (function) with supplied advice
+ *
  * @param joinPoint The function to be advised
  * @param type The type of advice to be applied
  * @param advice The advice to apply
  */
 function advise<F extends GenericFunction<T>, T>(joinPoint: F, type: AdviceType, advice: BeforeAdvice | AfterAdvice<T> | AroundAdvice<T>): F {
-	let dispatcher = joinPoint;
+	let dispatcher: F;
 	if (type === AdviceType.Around) {
 		dispatcher = getDispatcher(advice.apply(this, [ joinPoint ]));
 	}
 	else {
-		if (!dispatchAdviceMap.has(joinPoint)) {
-			dispatcher = getDispatcher(joinPoint);
-		}
+		dispatcher = getDispatcher(joinPoint);
 		const adviceMap = dispatchAdviceMap.get(dispatcher);
 		if (type === AdviceType.Before) {
 			(adviceMap.before || (adviceMap.before = [])).unshift(<BeforeAdvice> advice);
@@ -121,6 +141,7 @@ function advise<F extends GenericFunction<T>, T>(joinPoint: F, type: AdviceType,
 
 /**
  * Apply advice *before* the supplied joinPoint (function)
+ *
  * @param joinPoint A function that should have advice applied to
  * @param advice The before advice
  */
@@ -130,6 +151,7 @@ export function before<F extends GenericFunction<any>>(joinPoint: F, advice: Bef
 
 /**
  * Apply advice *after* the supplied joinPoint (function)
+ *
  * @param joinPoint A function that should have advice applied to
  * @param advice The after advice
  */
@@ -139,6 +161,7 @@ export function after<F extends GenericFunction<T>, T>(joinPoint: F, advice: Aft
 
 /**
  * Apply advice *around* the supplied joinPoint (function)
+ *
  * @param joinPoint A function that should have advice applied to
  * @param advice The around advice
  */

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,4 +1,3 @@
-import {  } from 'dojo-core/lang';
 import WeakMap from 'dojo-core/WeakMap';
 
 export interface AdvisingFunction extends Function {

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -109,8 +109,8 @@ registerSuite({
 				return prevResult + args[0] + 1;
 			}
 
-			const fn = after(foo, advice1);
-			after(fn, advice2);
+			let fn = after(foo, advice1);
+			fn = after(fn, advice2);
 			const result = fn(2);
 			assert.strictEqual(result, 7, '"result" should equal 7');
 			assert.deepEqual(calls, [ '1', '2' ], 'call should have been made in order');
@@ -194,10 +194,23 @@ registerSuite({
 				return origResult + args[0] + 1;
 			}
 
-			const fn = after(foo, adviceAfter);
-			before(fn, adviceBefore);
+			let fn = after(foo, adviceAfter);
+			fn = before(fn, adviceBefore);
 			const result = fn(2);
 			assert.strictEqual(result, 13, '"result" should equal 13');
 		}
+	},
+	'chained advice'() {
+		function foo(a: string): string {
+			return a;
+		}
+
+		function adviceAfter(origResult: string): string {
+			return origResult + 'foo';
+		}
+
+		const fn = after(after(foo, adviceAfter), adviceAfter);
+		after(fn, adviceAfter);
+		assert.strictEqual(fn('bar'), 'barfoofoo', 'should only apply advice twice');
 	}
 });

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1227,6 +1227,38 @@ registerSuite({
 				assert.strictEqual(resultFoo, 'foobarbarfoobar', '"resultFoo" should equal "foobarbarfoobar"');
 				assert.strictEqual(resultBar, 'foobarqat', '"resultBar" should equal "foobarqat"');
 			},
+			'multiple advice'() {
+				const createFoo = compose({
+					foo(a: string): string {
+						return a;
+					}
+				});
+
+				const createAspectFoo = createFoo
+					.mixin({
+						aspectAdvice: {
+							after: {
+								foo(previousResult: string): string {
+									return previousResult + 'foo';
+								}
+							}
+						}
+					});
+
+				createAspectFoo
+					.mixin({
+						aspectAdvice: {
+							after: {
+								foo(previousResult: string): string {
+									return previousResult + 'bar';
+								}
+							}
+						}
+					});
+
+				const foo = createAspectFoo();
+				assert.strictEqual(foo.foo('baz'), 'bazfoo', 'should only apply advice in chain');
+			},
 			'missing method': function () {
 				const createFoo = compose({
 					foo: function (a: string): string {


### PR DESCRIPTION
**Type:** bug

**Description:** 

Always 'clone' the advice dispatcher, so that references to an advised function are "immutable"
always returning new reference when advice is applied.

Previously, if a function was already advised and _before_ or _after_ advice was added, it was
simply added to the already existing advised function reference, which is _surprising_.  Therefore
it is necessary to always refer to the returned function when applying advice.

**Related Issue:** #40 

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [X] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged
