### PR TITLE
Migration to TS2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sublimets
 .tscache
+.tsconfig*.json
 *.js
 !/index.js
 *.js.map

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6.1'
+- '6'
 env:
   global:
   - BROWSERSTACK_USERNAME: dtktestaccount1
@@ -12,7 +12,7 @@ cache:
   directories:
   - node_modules
 install:
-- npm install grunt-cli dojo-has dojo-shim dojo-core
+- npm install grunt-cli
 - npm install
 script:
 - grunt

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/dojo/compose.git"
 	},
 	"scripts": {
-		"prepublish": "grunt dist",
+		"prepublish": "grunt peerDepInstall dist",
 		"test": "grunt test"
 	},
 	"typings": "./dist/umd/dojo-compose.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
 		"istanbul": "0.4.3",
 		"remap-istanbul": ">=0.6.4",
 		"tslint": "^3.7.4",
-		"typescript": "beta"
+		"typescript": "next"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 	},
 	"typings": "./dist/umd/dojo-compose.d.ts",
 	"peerDependencies": {
-		"dojo-core": ">=2.0.0-alpha.7",
 		"dojo-has": ">=2.0.0-alpha.1",
-		"dojo-shim": ">=2.0.0-alpha.1"
+		"dojo-shim": ">=2.0.0-alpha.1",
+		"dojo-core": ">=2.0.0-alpha.7"
 	},
 	"devDependencies": {
 		"@reactivex/rxjs": "5.0.0-beta.6",
@@ -32,7 +32,7 @@
 		"grunt-contrib-clean": "^1.0.0",
 		"grunt-contrib-copy": "^1.0.0",
 		"grunt-contrib-watch": "^1.0.0",
-		"grunt-dojo2": "2.0.0-beta.7",
+		"grunt-dojo2": ">=2.0.0-beta.7",
 		"grunt-release": "0.13.1",
 		"grunt-text-replace": "0.4.0",
 		"grunt-ts": "^5.5.1",
@@ -42,6 +42,6 @@
 		"istanbul": "0.4.3",
 		"remap-istanbul": ">=0.6.4",
 		"tslint": "^3.7.4",
-		"typescript": "~1.8.10"
+		"typescript": "beta"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 	},
 	"typings": "./dist/umd/dojo-compose.d.ts",
 	"peerDependencies": {
-		"dojo-has": ">=2.0.0-alpha.1",
-		"dojo-shim": ">=2.0.0-alpha.1",
-		"dojo-core": ">=2.0.0-alpha.7"
+		"dojo-has": "next",
+		"dojo-shim": "next",
+		"dojo-core": "next"
 	},
 	"devDependencies": {
 		"@reactivex/rxjs": "5.0.0-beta.6",

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -71,7 +71,7 @@ export interface GenericFunction<T> {
  */
 function getDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): F {
 
-	function dispatcher(...args: any[]): T {
+	function dispatcher(this: Function, ...args: any[]): T {
 		const { before, after, joinPoint } = dispatchAdviceMap.get(dispatcher);
 		if (before) {
 			args = before.reduce((previousArgs, advice) => {
@@ -120,7 +120,7 @@ function getDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): F {
  * @param type The type of advice to be applied
  * @param advice The advice to apply
  */
-function advise<F extends GenericFunction<T>, T>(joinPoint: F, type: AdviceType, advice: BeforeAdvice | AfterAdvice<T> | AroundAdvice<T>): F {
+function advise<F extends GenericFunction<T>, T>(this: any, joinPoint: F, type: AdviceType, advice: BeforeAdvice | AfterAdvice<T> | AroundAdvice<T>): F {
 	let dispatcher: F;
 	if (type === AdviceType.Around) {
 		dispatcher = getDispatcher(advice.apply(this, [ joinPoint ]));

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,3 +1,4 @@
+import { from as arrayFrom } from 'dojo-shim/array';
 import WeakMap from 'dojo-shim/WeakMap';
 import {
 	before as aspectBefore,
@@ -140,7 +141,7 @@ function cloneFactory(base?: any, staticProperties?: any): any {
 
 	if (base) {
 		copyProperties(factory.prototype, base.prototype);
-		initFnMap.set(factory, [].concat(initFnMap.get(base)));
+		initFnMap.set(factory, arrayFrom(initFnMap.get(base)));
 	}
 	else {
 		initFnMap.set(factory, []);

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -28,7 +28,7 @@ const staticPropertyMap = new WeakMap<Function, {}>();
  * @return    The rebased function
  */
 function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any {
-	return function(...args: any[]) {
+	return function(this: any, ...args: any[]) {
 		return fn.apply(this, [ this ].concat(args));
 	};
 }
@@ -129,7 +129,7 @@ function cloneFactory<T, O>(base: ComposeFactory<T, O>): ComposeFactory<T, O>;
 function cloneFactory<T, O>(): ComposeFactory<T, O>;
 function cloneFactory(base?: any, staticProperties?: any): any {
 
-	function factory(...args: any[]): any {
+	function factory(this: ComposeFactory<any, any>, ...args: any[]): any {
 		if (this && this.constructor === factory) {
 			throw new SyntaxError('Factories cannot be called with "new".');
 		}
@@ -488,7 +488,7 @@ function from<T extends Function>(base: GenericClass<any> | ComposeFactory<any, 
 	return base.prototype[method];
 }
 
-function doFrom<T, O>(base: GenericClass<any> | ComposeFactory<any, any>, method: string): ComposeFactory<T, O> {
+function doFrom<T, O>(this: ComposeFactory<T, O>, base: GenericClass<any> | ComposeFactory<any, any>, method: string): ComposeFactory<T, O> {
 	const clone = cloneFactory(this);
 	(<any> clone.prototype)[method] = base.prototype[method];
 	return clone as ComposeFactory<T, O>;
@@ -510,7 +510,7 @@ function before(...args: any[]): GenericFunction<any> {
 	return aspectBefore(<GenericFunction<any>> method, advice);
 }
 
-function doBefore<T, O>(method: string, advice: BeforeAdvice): ComposeFactory<T, O> {
+function doBefore<T, O>(this: ComposeFactory<T, O>, method: string, advice: BeforeAdvice): ComposeFactory<T, O> {
 	const clone = cloneFactory(this);
 	(<any> clone.prototype)[method] = aspectBefore((<any> clone.prototype)[method], advice);
 	return <ComposeFactory<T, O>> clone;
@@ -532,7 +532,7 @@ function after(...args: any[]): GenericFunction<any> {
 	return aspectAfter(<GenericFunction<any>> method, advice);
 }
 
-function doAfter<T, P, O>(method: string, advice: AfterAdvice<P>): ComposeFactory<T, O> {
+function doAfter<T, P, O>(this: ComposeFactory<T, O>, method: string, advice: AfterAdvice<P>): ComposeFactory<T, O> {
 	const clone = cloneFactory(this);
 	(<any> clone.prototype)[method] = aspectAfter((<any> clone.prototype)[method], advice);
 	return <ComposeFactory <T, O>> clone;
@@ -554,7 +554,7 @@ function around(...args: any[]): GenericFunction<any> {
 	return aspectAround(<GenericFunction<any>> method, advice);
 }
 
-function doAround<T, P, O>(method: string, advice: AroundAdvice<P>): ComposeFactory<T, O> {
+function doAround<T, P, O>(this: ComposeFactory<T, O>, method: string, advice: AroundAdvice<P>): ComposeFactory<T, O> {
 	const clone = cloneFactory(this);
 	(<any> clone.prototype)[method] = aspectAround((<any> clone.prototype)[method], advice);
 	return <ComposeFactory <T, O>> clone;

--- a/src/mixins/createDestroyable.ts
+++ b/src/mixins/createDestroyable.ts
@@ -56,7 +56,7 @@ export function isDestroyable(value: any): value is Destroyable {
  * *owns*
  */
 const createDestroyable: DestroyableFactory = compose({
-	own(handle: Handle): Handle {
+	own(this: Destroyable, handle: Handle): Handle {
 		const handles = handlesWeakMap.get(this);
 		handles.push(handle);
 		return {
@@ -66,7 +66,7 @@ const createDestroyable: DestroyableFactory = compose({
 			}
 		};
 	},
-	destroy() {
+	destroy(this: Destroyable) {
 		return new Promise((resolve) => {
 			const destroyable: Destroyable = this;
 			handlesWeakMap.get(destroyable).forEach((handle) => {

--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -115,7 +115,8 @@ function isActionable(value: any): value is Actionable<any> {
  */
 export function resolveListener<E extends TargettedEventObject>(listener: EventedListener<E>): EventedCallback<E> {
 	return isActionable(listener) ? function (event: E) {
-			listener.do({ event });
+			/* TODO: Resolve when Microsoft/TypeScript#8367 fixed */
+			(<Actionable<E>> listener).do({ event });
 		} : listener;
 }
 

--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -135,13 +135,13 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
  * Creates a new instance of an `Evented`
  */
 const createEvented: EventedFactory = compose<EventedMixin, EventedOptions>({
-		emit<E extends EventObject>(event: E): void {
+		emit<E extends EventObject>(this: Evented, event: E): void {
 			const method = listenersMap.get(this)[event.type];
 			if (method) {
 				method.call(this, event);
 			}
 		},
-		on(...args: any[]): Handle {
+		on(this: Evented, ...args: any[]): Handle {
 			const evented: Evented = this;
 			const listenerMap = listenersMap.get(evented);
 			if (args.length === 2) { /* overload: on(type, listener) */

--- a/src/mixins/createStateful.ts
+++ b/src/mixins/createStateful.ts
@@ -162,13 +162,12 @@ const createStateful: StatefulFactory = compose<StatefulMixin<State>, StatefulOp
 		},
 
 		setState(this: Stateful<State>, value: State): void {
-			const stateful: Stateful<State> = this;
-			const observedState = observedStateMap.get(stateful);
+			const observedState = observedStateMap.get(this);
 			if (observedState) {
 				observedState.observable.patch(value, { id: observedState.id });
 			}
 			else {
-				setStatefulState(stateful, value);
+				setStatefulState(this, value);
 			}
 		},
 

--- a/src/mixins/createStateful.ts
+++ b/src/mixins/createStateful.ts
@@ -157,11 +157,11 @@ const stateWeakMap = new WeakMap<Stateful<State>, State>();
  * Create an instance of a stateful object
  */
 const createStateful: StatefulFactory = compose<StatefulMixin<State>, StatefulOptions<State>>({
-		get state(): any {
+		get state(this: Stateful<State>): any {
 			return stateWeakMap.get(this);
 		},
 
-		setState(value: State): void {
+		setState(this: Stateful<State>, value: State): void {
 			const stateful: Stateful<State> = this;
 			const observedState = observedStateMap.get(stateful);
 			if (observedState) {
@@ -172,15 +172,15 @@ const createStateful: StatefulFactory = compose<StatefulMixin<State>, StatefulOp
 			}
 		},
 
-		observeState(id: string, observable: ObservableState<State>): Handle {
-			const stateful: Stateful<State> = this;
-			let observedState = observedStateMap.get(stateful);
+		observeState(this: Stateful<State>, id: string, observable: ObservableState<State>): Handle {
+			let observedState = observedStateMap.get(this);
 			if (observedState) {
 				if (observedState.id === id && observedState.observable === observable) {
 					return observedState.handle;
 				}
 				throw new Error(`Already observing state with ID '${observedState.id}'`);
 			}
+			const stateful = this;
 			observedState = {
 				id,
 				observable,

--- a/src/mixins/interfaces.ts
+++ b/src/mixins/interfaces.ts
@@ -28,7 +28,7 @@ export interface CompletionObserver<T> {
 
 export type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
-export class Observable<T> {
+export interface Observable<T> {
 	/**
 	 * Registers handlers for handling emitted values, error and completions from the observable, and
 	 *  executes the observable's subscriber function, which will take action to set up the underlying data stream

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -34,7 +34,7 @@ export const maxConcurrency = 1;
 export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string = (function () {
+export const initialBaseUrl: string | null = (function () {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -23,11 +23,11 @@ registerSuite({
 		},
 		'passes this': function () {
 			let result: number = 0;
-			function foo() {
+			function foo(this: any) {
 				result = this.a;
 			}
 
-			function advice() {
+			function advice(this: any) {
 				this.a = 2;
 			}
 
@@ -78,11 +78,11 @@ registerSuite({
 			assert.strictEqual(result, 4, '"result" should equal 4');
 		},
 		'passes this': function () {
-			function foo() {
+			function foo(this: any) {
 				return this.a;
 			}
 
-			function advice(prevResult: number) {
+			function advice(this: any, prevResult: number) {
 				this.c = prevResult + this.b;
 				return this.c;
 			}
@@ -123,7 +123,7 @@ registerSuite({
 			}
 
 			function advice(origFn: Function): (...args: any[]) => number {
-				return function(...args: any[]): number {
+				return function(this: any, ...args: any[]): number {
 					args[0] = args[0] + args[0];
 					let result = origFn.apply(this, args);
 					return ++result;
@@ -135,12 +135,12 @@ registerSuite({
 			assert.strictEqual(result, 5, '"result" should equal 5');
 		},
 		'preserves this': function () {
-			function foo(a: number): number {
+			function foo(this: any, a: number): number {
 				return this.a;
 			}
 
 			function advice(origFn: Function): (...args: any[]) => number {
-				return function(...args: any[]): number {
+				return function(this: any, ...args: any[]): number {
 					this.a = 2;
 					return origFn.apply(this, args);
 				};
@@ -158,7 +158,7 @@ registerSuite({
 			}
 
 			function advice1(origFn: Function): (...args: any[]) => number {
-				return function (...args: any[]): number {
+				return function (this: any, ...args: any[]): number {
 					calls.push('1');
 					args[0]++;
 					return origFn.apply(this, args) + 1;
@@ -166,7 +166,7 @@ registerSuite({
 			}
 
 			function advice2(origFn: Function): (...args: any[]) => number {
-				return function (...args: any[]): number {
+				return function (this: any, ...args: any[]): number {
 					calls.push('2');
 					args[0] += args[0];
 					return origFn.apply(this, args) + 1;

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -22,7 +22,7 @@ registerSuite({
 			assert.strictEqual(result, 4, '"result" should equal 4');
 		},
 		'passes this': function () {
-			let result: number;
+			let result: number = 0;
 			function foo() {
 				result = this.a;
 			}
@@ -38,7 +38,7 @@ registerSuite({
 			assert.strictEqual(result, 2, 'result should equal 2');
 		},
 		'multiple before advice': function () {
-			let result: number;
+			let result: number = 0;
 			const calls: string[] = [];
 			function foo(a: number) {
 				result = a;

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -150,7 +150,7 @@ registerSuite({
 				foo: function () {
 					counter++;
 				},
-				bar: <string> undefined
+				bar: ''
 			}, initFoo);
 
 			const foo = createFoo();
@@ -181,7 +181,7 @@ registerSuite({
 				foo: function () {
 					counter++;
 				},
-				bar: <string> undefined
+				bar: ''
 			};
 
 			function initFoo(instance: {foo: () => any, bar: string}, options?: any) {
@@ -723,18 +723,19 @@ registerSuite({
 				},
 				mixin: createBaz
 			});
-			createBar.mixin({
-				initialize: function(instance: { baz: number }, options: { baz: number }) {
+			/* Doesn't compile with new flow control typing, which maybe is a good thing? */
+			// createBar.mixin({
+			// 	initialize: function(instance: { baz: number }, options: { baz: number }) {
 
-				},
-				mixin: createBaz
-			});
-			createBar.mixin({
-				initialize: function(instance: { bar: string }, options: { bar: string }) {
+			// 	},
+			// 	mixin: createBaz
+			// });
+			// createBar.mixin({
+			// 	initialize: function(instance: { bar: string }, options: { bar: string }) {
 
-				},
-				mixin: createBaz
-			});
+			// 	},
+			// 	mixin: createBaz
+			// });
 			// Shouldn\'t compile
 			// const createBarBazIllegalInstanceType = createBar.mixin({
 			// initialize: function(instance: { baz: number; foo: number }) {

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -103,7 +103,7 @@ registerSuite({
 			assert.strictEqual(counter, 1, 'counter only called once');
 			assert.instanceOf(foo, createFoo, 'foo is an instanceOf Foo');
 		},
-		'typescript class': function () {
+		'typescript class': function (this: any) {
 			this.skip('initialised own values from classes not supported');
 			let result = 0;
 
@@ -268,7 +268,7 @@ registerSuite({
 				foo;
 			}, SyntaxError, 'Factories cannot be called with "new"');
 		},
-		'immutability': function () {
+		'immutability': function (this: any) {
 			'use strict';
 
 			if (typeof navigator !== 'undefined' && navigator.userAgent.match('Trident/5.0')) {
@@ -289,10 +289,10 @@ registerSuite({
 		'getters and setters': function() {
 			const createFoo = compose({
 				_foo: '',
-				set foo(foo) {
+				set foo(this: any, foo) {
 					this._foo = foo;
 				},
-				get foo() {
+				get foo(this: any) {
 					return this._foo;
 				}
 			});
@@ -307,7 +307,7 @@ registerSuite({
 		'only getter': function() {
 			const createFoo = compose({
 				_foo: '',
-				get foo() {
+				get foo(this: any) {
 					return this._foo + 'bar';
 				}
 			});
@@ -322,7 +322,7 @@ registerSuite({
 		'only setter': function() {
 			const createFoo = compose({
 				_foo: '',
-				set foo(foo: string) {
+				set foo(this: any, foo: string) {
 					this._foo = foo;
 				}
 			});
@@ -604,9 +604,9 @@ registerSuite({
 			assert.strictEqual(foo.foo, 'bar', 'initialize was called');
 		},
 
-		'only aspect': function() {
+		'only aspect': function(this: any) {
 			const createFoo = compose({
-				foo: function() {
+				foo: function(this: any) {
 					this.baz = 'bar';
 				},
 				bar: '',
@@ -614,7 +614,7 @@ registerSuite({
 			}).mixin({
 				aspectAdvice: {
 					after: {
-						foo: function() {
+						foo: function(this: any) {
 							this.bar = 'baz';
 						}
 					}
@@ -633,7 +633,7 @@ registerSuite({
 					foo: 'foo',
 					bar: '',
 					doneFoo: false,
-					doFoo: function() {
+					doFoo: function(this: any) {
 						this.foo = 'bar';
 					}
 				}),
@@ -642,7 +642,7 @@ registerSuite({
 				},
 				aspectAdvice: {
 					after: {
-						doFoo: function() {
+						doFoo: function(this: any) {
 							this.doneFoo = true;
 						}
 					}
@@ -985,7 +985,7 @@ registerSuite({
 				}
 
 				function advice(origFn: (a: string) => string): (...args: any[]) => string {
-					return function(...args: any[]): string {
+					return function(this: any, ...args: any[]): string {
 						args[0] = args[0] + 'bar';
 						return origFn.apply(this, args) + 'qat';
 					};
@@ -1005,7 +1005,7 @@ registerSuite({
 				}
 
 				function advice(origFn: (a: string) => string): (...args: any[]) => string {
-					return function(...args: any[]): string {
+					return function(this: any, ...args: any[]): string {
 						args[0] = args[0] + 'bar';
 						return origFn.apply(this, args) + 'qat';
 					};
@@ -1027,7 +1027,7 @@ registerSuite({
 				}
 
 				function advice(origFn: (a: string) => string): (...args: any[]) => string {
-					return function(...args: any[]): string {
+					return function(this: any, ...args: any[]): string {
 						args[0] = args[0] + 'bar';
 						return origFn.apply(this, args) + 'qat';
 					};
@@ -1092,7 +1092,7 @@ registerSuite({
 					const createAroundFoo = compose.aspect(createFoo, {
 						around: {
 							foo: function (origFn: (a: string) => string): (...args: any[]) => string {
-								return function(...args: any[]): string {
+								return function(this: any, ...args: any[]): string {
 									args[0] = args[0] + 'bar';
 									return origFn.apply(this, args) + 'qat';
 								};
@@ -1104,7 +1104,7 @@ registerSuite({
 					const result = foo.foo('foo');
 					assert.strictEqual(result, 'foobarqat', '"result" should qual "foobarqat"');
 				},
-				'mixed': function () {
+				'mixed': function (this: any) {
 					const createFoo = compose({
 						foo: function (a: string): string {
 							return a;
@@ -1128,7 +1128,7 @@ registerSuite({
 						},
 						around: {
 							bar: function (origFn: (a: string) => string): (...args: any[]) => string {
-								return function(...args: any[]): string {
+								return function(this: any, ...args: any[]): string {
 									args[0] = args[0] + 'bar';
 									return origFn.apply(this, args) + 'qat';
 								};
@@ -1214,7 +1214,7 @@ registerSuite({
 					},
 					around: {
 						bar: function (origFn: (a: string) => string): (...args: any[]) => string {
-							return function(...args: any[]): string {
+							return function(this: any, ...args: any[]): string {
 								args[0] = args[0] + 'bar';
 								return origFn.apply(this, args) + 'qat';
 							};
@@ -1317,7 +1317,7 @@ registerSuite({
 				const createFoo = compose({
 					foo: 1
 				}).static({
-					factoryDescriptor(): ComposeMixinDescriptor<any, any, { foo: number }, any> {
+					factoryDescriptor(this: any): ComposeMixinDescriptor<any, any, { foo: number }, any> {
 						return {
 							mixin: this,
 							initialize: function(instance: { foo: number }) {

--- a/tests/unit/mixins/createStateful.ts
+++ b/tests/unit/mixins/createStateful.ts
@@ -29,7 +29,7 @@ registerSuite({
 					});
 				},
 				patch(value: any, options?: { id?: string }): Promise<State> {
-					assert.strictEqual(options.id, 'foo');
+					assert.strictEqual(options && options.id, 'foo');
 					return Promise.resolve(value);
 				}
 			};
@@ -56,7 +56,7 @@ registerSuite({
 					});
 				},
 				patch(value: any, options?: { id?: string }): Promise<State> {
-					assert.strictEqual(options.id, 0);
+					assert.strictEqual(options && options.id, 0);
 					return Promise.resolve(value);
 				}
 			};
@@ -150,7 +150,7 @@ registerSuite({
 				patch(value: any, options?: { id?: string }): Promise<State> {
 					patchCalled++;
 					observerRef.next(value);
-					assert.strictEqual(options.id, 'foo');
+					assert.strictEqual(options && options.id, 'foo');
 					return Promise.resolve(value);
 				}
 			};
@@ -174,7 +174,7 @@ registerSuite({
 		},
 		'observeState() - completed'() {
 			let called = 0;
-			let observerRef: Observer<State>;
+			let observerRef: Observer<State> = <any> undefined;
 			const observer = {
 				observe(id: string): Observable<State> {
 					assert.strictEqual(id, 'foo');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic",
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		"noImplicitThis": true
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
-		"moduleResolution": "classic"
+		"moduleResolution": "classic",
+		"strictNullChecks": true
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,41 +1,30 @@
 {
-	"version": "1.7.0",
+	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
 		"outDir": "_build/",
+		"baseUrl": "node_modules",
+		"paths": {
+			"dojo-has/*": [
+				"dojo-has/dist/umd/*"
+			],
+			"dojo-shim/*": [
+				"dojo-shim/dist/umd/*"
+			],
+			"dojo-core/*": [
+				"dojo-core/dist/umd/*"
+			]
+		},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic"
 	},
-	"filesGlob": [
+	"include": [
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
-		"./typings/index.d.ts"
-	],
-	"files": [
-		"./src/aspect.ts",
-		"./src/compose.ts",
-		"./src/main.ts",
-		"./src/mixins/createDestroyable.ts",
-		"./src/mixins/createEvented.ts",
-		"./src/mixins/createStateful.ts",
-		"./src/mixins/interfaces.d.ts",
-		"./tests/functional/all.ts",
-		"./tests/intern-local.ts",
-		"./tests/intern-saucelabs.ts",
-		"./tests/intern.ts",
-		"./tests/support/Reporter.ts",
-		"./tests/unit/all.ts",
-		"./tests/unit/aspect.ts",
-		"./tests/unit/compose.ts",
-		"./tests/unit/main.ts",
-		"./tests/unit/mixins/all.ts",
-		"./tests/unit/mixins/createDestroyable.ts",
-		"./tests/unit/mixins/createEvented.ts",
-		"./tests/unit/mixins/createStateful.ts",
 		"./typings/index.d.ts"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -4,9 +4,6 @@
 		"@reactivex/RxJS": "npm:@reactivex/rxjs"
 	},
 	"globalDependencies": {
-		"dojo-core": "npm:dojo-core",
-		"dojo-shim": "npm:dojo-shim",
-		"dojo-has": "npm:dojo-has",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Dependant on has, shim, core TS2.0 updates
- [x] Upgrade to TS2.0 (beta)
- [x] Convert to use `paths` and `baseUrl` for UMD type discovery
- [x] Add `strictNullChecks`
- [x] Add `noImplicitThis`

Fixes #28 
