### PR TITLE
Merge arrays on prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,36 @@ The previous example, where a `ComposeFactory` was passed directly to `mixin` is
 are initialized with a version of the `factoryDescriptor` function that simply returns the factory itself as the `mixin` property. If a more complicated
 factory descriptor is required, the `factoryDescriptor` method can be overridden using the `static` method, documented below.
 
+### Merging of Arrays
+
+When mixing in or extending classes which contain array literals as a value of a property, `compose` will merge these values
+instead of over writting, which it does with other value types.
+
+For example, if I have an array of strings in my original class, and provide a mixin which shares the same property that is
+also an array, those will get merged:
+
+```typescript
+const createFoo = compose({
+	foo: [ 'foo' ]
+});
+
+const createBarMixin = compose({
+	foo: [ 'bar' ]
+});
+
+const createFooBar = createFoo.mixin(createBarMixin);
+
+const foo = createFooBar();
+
+foo.foo; // [ 'foo', 'bar' ]
+```
+
+There are some things to note:
+
+* The merge process will eliminate duplicates.
+* When the factory is invoked, it will "duplicate" the array from the prototype, so `createFoo.prototype.foo !== foo.foo`.
+* If the source and the target are not arrays, like other mixing in, last one wins.
+
 ### Using Generics
 
 `compose` utilizes TypeScript generics and type inference to type the resulting classes.  Most of the time, this will work without any need to declare your types.  There are situations though where you may want to be more explicit about your interfaces and `compose` can accommodate that by passing in generics when using the API. Here is an example of creating a class that requires generics using `compose`:

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,4 +1,4 @@
-import { from as arrayFrom } from 'dojo-shim/array';
+import { from as arrayFrom, includes } from 'dojo-shim/array';
 import WeakMap from 'dojo-shim/WeakMap';
 import {
 	before as aspectBefore,
@@ -37,13 +37,23 @@ function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any
  * A helper function that copies own properties and their descriptors
  * from one or more sources to a target object. Includes non-enumerable properties
  */
-function copyProperties(target: {}, ...sources: {}[]) {
-	sources.forEach(source => {
+function copyProperties(target: any, ...sources: any[]) {
+	sources.forEach((source) => {
 		Object.defineProperties(
 			target,
 			Object.getOwnPropertyNames(source).reduce(
 				(descriptors: { [ index: string ]: any }, key: string) => {
-					descriptors[ key ] = Object.getOwnPropertyDescriptor(source, key);
+					/* Special handling to merge array proprties */
+					const descriptor = Object.getOwnPropertyDescriptor(source, key);
+					if (Array.isArray(descriptor.value) && Array.isArray(target[key])) {
+						descriptor.value = descriptor.value.reduce((value: any[], current: any) => {
+							if (!includes(target[key], current)) {
+								value.push(current);
+							}
+							return value;
+						}, target[key]);
+					}
+					descriptors[key] = descriptor;
 					return descriptors;
 				},
 				{}
@@ -134,6 +144,14 @@ function cloneFactory(base?: any, staticProperties?: any): any {
 			throw new SyntaxError('Factories cannot be called with "new".');
 		}
 		const instance = Object.create(factory.prototype);
+
+		/* Clone any arrays in the instance */
+		for (const key in instance) {
+			if (Array.isArray(instance[key])) {
+				instance[key] = arrayFrom(instance[key]);
+			}
+		}
+
 		args.unshift(instance);
 		initFnMap.get(factory).forEach(fn => fn.apply(null, args));
 		return instance;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -147,7 +147,7 @@ function cloneFactory(base?: any, staticProperties?: any): any {
 
 		/* Clone any arrays in the instance */
 		for (const key in instance) {
-			if (Array.isArray(instance[key])) {
+			if (Array.isArray(Object.getOwnPropertyDescriptor(factory.prototype, key).value)) {
 				instance[key] = arrayFrom(instance[key]);
 			}
 		}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -51,7 +51,7 @@ function copyProperties(target: any, ...sources: any[]) {
 								value.push(current);
 							}
 							return value;
-						}, target[key]);
+						}, arrayFrom(target[key]));
 					}
 					descriptors[key] = descriptor;
 					return descriptors;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -42,21 +42,29 @@ function copyProperties(target: any, ...sources: any[]) {
 		Object.defineProperties(
 			target,
 			Object.getOwnPropertyNames(source).reduce(
-				(descriptors: { [ index: string ]: any }, key: string) => {
+				(descriptors: PropertyDescriptorMap, key: string) => {
+					const sourceDescriptor = Object.getOwnPropertyDescriptor(source, key);
+					const sourceValue = sourceDescriptor && sourceDescriptor.value;
+					const targetDescriptor = Object.getOwnPropertyDescriptor(target, key);
+					const targetValue = targetDescriptor && targetDescriptor.value;
+
 					/* Special handling to merge array proprties */
-					const descriptor = Object.getOwnPropertyDescriptor(source, key);
-					if (Array.isArray(descriptor.value) && Array.isArray(target[key])) {
-						descriptor.value = descriptor.value.reduce((value: any[], current: any) => {
-							if (!includes(target[key], current)) {
-								value.push(current);
-							}
-							return value;
-						}, arrayFrom(target[key]));
+					if (Array.isArray(sourceValue) && Array.isArray(targetValue)) {
+						sourceDescriptor.value = sourceValue.reduce(
+							(value: any[], current: any) => {
+								if (!includes(target[key], current)) {
+									value.push(current);
+								}
+								return value;
+							},
+							arrayFrom(targetValue)
+						);
 					}
-					descriptors[key] = descriptor;
+
+					descriptors[key] = sourceDescriptor;
 					return descriptors;
 				},
-				{}
+				Object.create(null)
 			)
 		);
 	});

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -389,6 +389,16 @@ registerSuite({
 			assert.notInclude(Object.keys(fooPrototype), 'nonEnumerable', 'Keys included non-enumerable property');
 			assert.include(Object.getOwnPropertyNames(fooPrototype), 'nonEnumerable',
 				'Own property names did not include non-enumerable property');
+		},
+
+		'array prototype property': function() {
+			const arr = [ function () { return 'foo'; }, function () { return 'bar'; } ];
+			const createFoo = compose({ arr });
+			const foo = createFoo();
+			assert.isArray(foo.arr);
+			assert.notStrictEqual(foo.arr, arr);
+			assert.deepEqual(foo.arr, arr);
+			assert.deepEqual([ 'foo', 'bar' ], arr.map((value) => value()));
 		}
 	},
 	extend: {
@@ -434,6 +444,60 @@ registerSuite({
 
 			assert.strictEqual(fooBar.foo, 'bar', 'Should have run original init function');
 			assert.strictEqual(fooBar.bar, 'bar', 'Should have included extension type and not init function');
+		},
+		'arrays': {
+			'present in base': function () {
+				const createFoo = compose.create({
+					foo: [ 'bar' ]
+				}).extend({
+					foo: [ 'baz' ]
+				}).extend({
+					foo: [ 'qat' ]
+				});
+
+				const foo = createFoo();
+
+				assert.deepEqual(foo.foo, [ 'bar', 'baz', 'qat' ]);
+			},
+
+			'not present in base': function () {
+				const createFoo = compose.create({
+					foo: 'bar'
+				}).extend({
+					bar: [ 'bar' ]
+				});
+
+				const foo = createFoo();
+
+				assert.deepEqual(foo.bar, [ 'bar' ]);
+			},
+
+			'overwrite in base': function () {
+				const createFoo = compose.create({
+					foo: 'bar',
+					bar: [ 'bar' ]
+				}).extend({
+					foo: [ 'bar' ],
+					bar: 'foo'
+				});
+
+				const foo = createFoo();
+
+				assert.deepEqual(foo.foo, [ 'bar' ]);
+				assert.deepEqual(foo.bar, 'foo');
+			},
+
+			'merging duplicates': function () {
+				const createFoo = compose.create({
+					foo: [ 'foo', 'bar' ]
+				}).extend({
+					foo: [ 'bar', 'baz' ]
+				});
+
+				const foo = createFoo();
+
+				assert.deepEqual(foo.foo, [ 'foo', 'bar', 'baz' ]);
+			}
 		}
 	},
 	mixin: {
@@ -773,6 +837,81 @@ registerSuite({
 			const fooBar = createFooBar();
 			assert.strictEqual(fooBar.foo, 'foo', 'Foo property not present');
 			assert.strictEqual(fooBar.bar, 3, 'Bar property not present');
+		},
+
+		'arrays': {
+			'present in base': function () {
+				const createFoo = compose({
+					foo: [ 'foo' ]
+				});
+
+				const createBar = compose({
+					foo: [ 'bar' ]
+				});
+
+				const createBaz = compose({
+					foo: [ 'baz' ]
+				});
+
+				const createFooBarBaz = createFoo
+					.mixin(createBar)
+					.mixin(createBaz);
+
+				const foobarbaz = createFooBarBaz();
+
+				assert.deepEqual(foobarbaz.foo, [ 'foo', 'bar', 'baz' ]);
+			},
+
+			'not present in base': function () {
+				const createFoo = compose({
+					foo: 'bar'
+				});
+
+				const createBar = compose({
+					bar: [ 'bar' ]
+				});
+
+				const createFooBar = createFoo.mixin(createBar);
+
+				const foo = createFooBar();
+
+				assert.deepEqual(foo.bar, [ 'bar' ]);
+			},
+
+			'overwrite in base': function () {
+				const createFoo = compose({
+					foo: 'bar',
+					bar: [ 'bar' ]
+				});
+
+				const createBar = compose({
+					foo: [ 'bar' ],
+					bar: 'foo'
+				});
+
+				const createFooBar = createFoo.mixin(createBar);
+
+				const foo = createFooBar();
+
+				assert.deepEqual(foo.foo, [ 'bar' ]);
+				assert.deepEqual(foo.bar, 'foo');
+			},
+
+			'merging duplicates': function () {
+				const createFoo = compose({
+					foo: [ 'foo', 'bar' ]
+				});
+
+				const createBar = compose({
+					foo: [ 'bar', 'baz' ]
+				});
+
+				const createFooBar = createFoo.mixin(createBar);
+
+				const foo = createFooBar();
+
+				assert.deepEqual(foo.foo, [ 'foo', 'bar', 'baz' ]);
+			}
 		}
 	},
 	overlay: {

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -511,6 +511,18 @@ registerSuite({
 				const foo = createFoo();
 
 				assert.deepEqual(foo.foo, [ 'foo', 'bar', 'baz' ]);
+			},
+
+			'arrays on prototype are not equal': function () {
+				const arr1 = [ 'foo', 'bar' ];
+				const arr2 = [ 'bar', 'baz' ];
+				const createFoo = compose({ arr: arr1 });
+				const createBar = createFoo.extend({ arr: arr2 });
+				assert.deepEqual(arr1, [ 'foo', 'bar' ]);
+				assert.deepEqual(arr2, [ 'bar', 'baz' ]);
+				assert.strictEqual(createFoo.prototype.arr, arr1);
+				assert.deepEqual(createFoo.prototype.arr, [ 'foo', 'bar' ]);
+				assert.deepEqual(createBar.prototype.arr, [ 'foo', 'bar', 'baz' ]);
 			}
 		}
 	},
@@ -925,6 +937,20 @@ registerSuite({
 				const foo = createFooBar();
 
 				assert.deepEqual(foo.foo, [ 'foo', 'bar', 'baz' ]);
+			},
+
+			'arrays on prototype are not equal': function () {
+				const arr1 = [ 'foo', 'bar' ];
+				const arr2 = [ 'bar', 'baz' ];
+				const createFoo = compose({ arr: arr1 });
+				const createBar = compose({ arr: arr2 });
+				const createFooBar = createFoo.mixin(createBar);
+				assert.deepEqual(arr1, [ 'foo', 'bar' ]);
+				assert.deepEqual(arr2, [ 'bar', 'baz' ]);
+				assert.strictEqual(createFoo.prototype.arr, arr1);
+				assert.deepEqual(createFoo.prototype.arr, [ 'foo', 'bar' ]);
+				assert.deepEqual(createBar.prototype.arr, [ 'bar', 'baz' ]);
+				assert.deepEqual(createFooBar.prototype.arr, [ 'foo', 'bar', 'baz' ]);
 			}
 		}
 	},

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -399,6 +399,20 @@ registerSuite({
 			assert.notStrictEqual(foo.arr, arr);
 			assert.deepEqual(foo.arr, arr);
 			assert.deepEqual([ 'foo', 'bar' ], arr.map((value) => value()));
+		},
+
+		'getters not accessed during creation': function () {
+			let count = 0;
+			const createFoo = compose({
+				get foo() {
+					count++;
+					return [];
+				}
+			});
+			const foo = createFoo();
+			assert.strictEqual(count, 0);
+			assert.isArray(foo.foo);
+			assert.strictEqual(count, 1);
 		}
 	},
 	extend: {


### PR DESCRIPTION
**Type:** feature

**Related Issue:** #46

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [X] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged

This commit allows for arrays to merged on prototypes when the target
and the source contain a property that is an array in both.  In addition
any arrays in the prototype during construction will be duplicated
so that the instance will not refer to the array in the prototype.

Fixes #46
