### PR TITLE
Stateful calls .destroy on state observation complete

### DIFF
--- a/src/mixins/createStateful.ts
+++ b/src/mixins/createStateful.ts
@@ -5,6 +5,7 @@ import WeakMap from 'dojo-shim/WeakMap';
 import { Observable, Subscription } from './interfaces';
 import createEvented, { Evented, EventedOptions, EventedListener, TargettedEventObject } from './createEvented';
 import compose, { ComposeFactory } from '../compose';
+import createCancelableEvent, { CancelableEvent } from '../util/createCancelableEvent';
 
 /**
  * Base State interface
@@ -91,7 +92,18 @@ export interface StatefulMixin<S extends State>{
 
 export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
 	/**
-	 * Add a listener for an event
+	 * Add a listener for a `statecomplete` event, which occures when state is observed
+	 * and is completed.  If the event is not cancelled, the instance will continue and
+	 * call `target.destroy()`.
+	 *
+	 * @param type The event type to listen for
+	 * @param listener The listener that will be called when the event occurs
+	 */
+	on(type: 'statecomplete', listener: EventedListener<CancelableEvent<'statecomplete', Stateful<S>>>): Handle;
+
+	/**
+	 * Add a listener for a `statechange` event, which occures whenever the state changes on the instance.
+	 *
 	 * @param type The event type to listen for
 	 * @param listener The listener that will be called when the event occurs
 	 */
@@ -119,23 +131,30 @@ interface ObservedState {
 const observedStateMap = new WeakMap<Stateful<State>, ObservedState>();
 
 /**
- * Internal function to unobserve the state of a `Stateful`
+ * Internal function to unobserve the state of a `Stateful`.  It emits a `statecomplete` event which can be
+ * cancelled.
+ *
  * @param stateful The `Stateful` object to unobserve
  */
 function unobserve(stateful: Stateful<State>): void {
 	const observedState = observedStateMap.get(stateful);
 	if (observedState) {
 		observedState.handle.destroy();
-		stateful.emit({
-			type: 'observe:complete',
+		const statecomplete = createCancelableEvent({
+			type: 'statecomplete',
 			target: stateful
 		});
+		stateful.emit(statecomplete);
+		if (!statecomplete.defaultPrevented) {
+			stateful.destroy();
+		}
 	}
 }
 
 /**
  * Internal function that actually applies the state to the Stateful's state and
  * emits the `statechange` event.
+ *
  * @param stateful The Stateful instance
  * @param state The State to be set
  */

--- a/src/util/createCancelableEvent.ts
+++ b/src/util/createCancelableEvent.ts
@@ -1,0 +1,48 @@
+export interface CancelableEvent<T extends string, U> {
+	/**
+	 * The type of the event
+	 */
+	readonly type: T;
+
+	/**
+	 * The target for the event
+	 */
+	readonly target: U;
+
+	/**
+	 * Can the event be canceled?
+	 */
+	readonly cancelable: boolean;
+
+	/**
+	 * Was the event canceled?
+	 */
+	readonly defaultPrevented: boolean;
+
+	/**
+	 * Cancel the event
+	 */
+	preventDefault(): void;
+}
+
+/**
+ * A simple factory that creates an event object which can be cancelled
+ *
+ * @param options The options for the event
+ */
+function createCancelableEvent<T extends string, U>(options: { type: T, target: U }): CancelableEvent<T, U> {
+	const { type, target } = options;
+	const event: CancelableEvent<T, U> = Object.defineProperties({}, {
+		type: { value: type, enumerable: true },
+		target: { value: target, enumerable: true },
+		cancelable: { value: true, enumerable: true },
+		defaultPrevented: { value: false, enumerable: true, configurable: true },
+		preventDefault: { value() {
+			Object.defineProperty(event, 'defaultPrevented', { value: true, enumerable: true });
+		}, enumerable: true }
+	});
+
+	return event;
+}
+
+export default createCancelableEvent;

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -2,3 +2,4 @@ import './aspect';
 import './compose';
 import './main';
 import './mixins/all';
+import './util/all';

--- a/tests/unit/util/all.ts
+++ b/tests/unit/util/all.ts
@@ -1,0 +1,1 @@
+import './createCancelableEvent';

--- a/tests/unit/util/createCancelableEvent.ts
+++ b/tests/unit/util/createCancelableEvent.ts
@@ -1,0 +1,52 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import createCancelableEvent from '../../../src/util/createCancelableEvent';
+
+registerSuite({
+	name: 'util/createCancelableEvent',
+	'create event'() {
+		const target = { foo: 'bar' };
+		const event = createCancelableEvent({
+			type: 'foo',
+			target
+		});
+
+		assert.strictEqual(event.type, 'foo');
+		assert.strictEqual(event.target, target);
+		assert.isFunction(event.preventDefault);
+		assert.isFalse(event.defaultPrevented);
+		assert.isTrue(event.cancelable);
+	},
+	'cancel event'() {
+		const event = createCancelableEvent({
+			type: 'foo',
+			target: {}
+		});
+
+		assert.isFalse(event.defaultPrevented);
+		event.preventDefault();
+		assert.isTrue(event.defaultPrevented);
+	},
+	'immutable properties'() {
+		const event = createCancelableEvent({
+			type: 'foo',
+			target: {}
+		});
+		assert.throws(() => {
+			(<any> event).target = {};
+		});
+		// This is a compiler error in TS2.1 (next)
+		// assert.throws(() => {
+		// 	event.type = 'bar';
+		// });
+		assert.throws(() => {
+			(<any> event).cancelable = false;
+		});
+		assert.throws(() => {
+			(<any> event).defaultPrevented = true;
+		});
+		assert.throws(() => {
+			event.preventDefault = () => {};
+		});
+	}
+});


### PR DESCRIPTION
**Type:** feature

**Related Issue:** #60 

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [X] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged

**Description:** 

Stateful now issues a cancellable event of `statecomplete` which if not cancelled will cause Stateful to call `.destroy()`.
