### PR TITLE
Initial Debugging Features

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -342,7 +342,9 @@ export interface ComposeFactory<T, O> extends ComposeMixinable<T, O> {
 	 * @template P The type of the extension factory options
 	 */
 	extend<U>(extension: U | GenericClass<U>): ComposeFactory<T & U, O>;
+	extend<U>(className: string, extension: U | GenericClass<U>): ComposeFactory<T & U, O>;
 	extend<U, P>(extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+	extend<U, P>(className: string, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 }
 
 export interface Compose {
@@ -358,7 +360,9 @@ export interface Compose {
 	 * @template P The type of the extension factory options
 	 */
 	extend<T, O, U>(base: ComposeFactory<T, O>, extension: U | GenericClass<U>): ComposeFactory<T & U, O>;
+	extend<T, O, U>(base: ComposeFactory<T, O>, className: string, extension: U | GenericClass<U>): ComposeFactory<T & U, O>;
 	extend<T, O, U, P>(base: ComposeFactory<T, O>, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+	extend<T, O, U, P>(base: ComposeFactory<T, O>, className: string, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 }
 
 /**
@@ -367,8 +371,13 @@ export interface Compose {
  * @param base The base compose factory that is being extended
  * @param extension The extension to apply to the compose factory
  */
-function extend<T, O, U, P>(base: ComposeFactory<T, O>, extension: ComposeFactory<U, P>, className?: string): ComposeFactory<T & U, O & P>;
-function extend<O>(base: ComposeFactory<any, O>, extension: any, className?: string): ComposeFactory<any, O> {
+function extend<T, O, U, P>(base: ComposeFactory<T, O>, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+function extend<T, O, U, P>(base: ComposeFactory<T, O>, className: string, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+function extend<O>(base: ComposeFactory<any, O>, className: any, extension?: any): ComposeFactory<any, O> {
+	if (typeof className !== 'string') {
+		extension = className;
+		className = undefined;
+	}
 	base = cloneFactory(base, className);
 	copyProperties(base.prototype, typeof extension === 'function' ? extension.prototype : extension);
 	return base;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -16,6 +16,11 @@ import {
 const initFnMap = new WeakMap<Function, ComposeInitializationFunction<any, any>[]>();
 
 /**
+ * The default factory label if no label can be derived during the factory creation process
+ */
+const COMPOSE_LABEL = 'Compose';
+
+/**
  * Reference to defineProperty to support minification
  */
 const defineProperty = Object.defineProperty;
@@ -250,9 +255,7 @@ function cloneFactory(base?: any, staticProperties?: any, name?: string): any {
 	else {
 		initFnMap.set(factory, []);
 	}
-	if (name) {
-		labelFactory(factory, name);
-	}
+	labelFactory(factory, name || (base && base.name) || COMPOSE_LABEL);
 	factory.prototype.constructor = factory;
 	stamp(factory);
 	if (staticProperties) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -562,7 +562,7 @@ function mixin<T, O, U, P>(
 			if (!includes(baseInitFns, mixin.initialize)) {
 				setFunctionName(
 					mixin.initialize,
-					`mixin${mixin.className || (isComposeFactory(mixin.mixin) && mixin.mixin.name) || base.name || 'Anonymous'}`
+					`mixin${mixin.className || (isComposeFactory(mixin.mixin) && mixin.mixin.name) || base.name}`
 				);
 				baseInitFns.push(mixin.initialize);
 			}
@@ -575,7 +575,7 @@ function mixin<T, O, U, P>(
 		if (!includes(baseInitFns, mixin.initialize)) {
 			setFunctionName(
 				mixin.initialize,
-				`mixin${mixin.className || base.name || 'Anonymous'}`
+				`mixin${mixin.className || base.name}`
 			);
 			baseInitFns.push(mixin.initialize);
 		}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -297,7 +297,7 @@ function concatInitFn<T, O, U, P>(target: ComposeFactory<T, O>, source: ComposeF
  * @returns       Return true if it is a ComposeFactory, otherwise false
  */
 export function isComposeFactory(value: any): value is ComposeFactory<any, any> {
-	return Boolean(initFnMap.get(value));
+	return Boolean(value && initFnMap.get(value));
 }
 
 /* General Interfaces */

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -566,7 +566,7 @@ function mixin<T, O, U, P>(
 		if (!includes(baseInitFns, mixin.initialize)) {
 			labelFunction(
 				mixin.initialize,
-				`mixin${mixin.className || (isComposeFactory(mixin.mixin) && mixin.mixin.name) || base.name}`
+				`mixin${mixin.className || base.name || 'Anonymous'}`
 			);
 			baseInitFns.push(mixin.initialize);
 		}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -560,7 +560,7 @@ function mixin<T, O, U, P>(
 		}
 		copyProperties(base.prototype, mixinFactory.prototype);
 	}
-	else if (base && mixin.initialize) {
+	else if (mixin.initialize) {
 		/* TODO: We should be able to combine with the logic above */
 		const baseInitFns = initFnMap.get(base);
 		if (!includes(baseInitFns, mixin.initialize)) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -566,7 +566,7 @@ function mixin<T, O, U, P>(
 		if (!includes(baseInitFns, mixin.initialize)) {
 			labelFunction(
 				mixin.initialize,
-				`mixin${mixin.className || (isComposeFactory(mixin.mixin) && mixin.mixin.name) || base.name || 'Anonymous'}`
+				`mixin${mixin.className || (isComposeFactory(mixin.mixin) && mixin.mixin.name) || base.name}`
 			);
 			baseInitFns.push(mixin.initialize);
 		}

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -29,11 +29,14 @@ const staticPropertyMap = new WeakMap<Function, {}>();
  * Internal function which can label a function with a name
  */
 function labelFunction(fn: Function, value: string): void {
-	defineProperty(fn, 'name', {
-		value,
-		writable: true,
-		configurable: true
-	});
+	const nameDescriptor = Object.getOwnPropertyDescriptor(fn, 'name');
+	if (typeof nameDescriptor === 'undefined' || nameDescriptor.configurable) {
+		defineProperty(fn, 'name', {
+			value,
+			writable: true,
+			configurable: true
+		});
+	}
 }
 
 /**
@@ -557,7 +560,7 @@ function mixin<T, O, U, P>(
 		}
 		copyProperties(base.prototype, mixinFactory.prototype);
 	}
-	else if (mixin.initialize) {
+	else if (base && mixin.initialize) {
 		/* TODO: We should be able to combine with the logic above */
 		const baseInitFns = initFnMap.get(base);
 		if (!includes(baseInitFns, mixin.initialize)) {

--- a/src/mixins/createDestroyable.ts
+++ b/src/mixins/createDestroyable.ts
@@ -58,7 +58,7 @@ export function isDestroyable(value: any): value is Destroyable {
  * A mixin which adds the concepts of being able to *destroy* handles which the instance
  * *owns*
  */
-const createDestroyable: DestroyableFactory = compose({
+const createDestroyable: DestroyableFactory = compose('Destroyable', {
 	own(this: Destroyable, handle: Handle): Handle {
 		const handles = handlesWeakMap.get(this);
 		handles.push(handle);

--- a/src/mixins/createEvented.ts
+++ b/src/mixins/createEvented.ts
@@ -172,6 +172,7 @@ const createEvented: EventedFactory = compose<EventedMixin, EventedOptions>({
 		}
 	})
 	.mixin({
+		className: 'Evented',
 		mixin: createDestroyable,
 		initialize(instance, options) {
 			/* Initialise listener map */

--- a/src/mixins/createStateful.ts
+++ b/src/mixins/createStateful.ts
@@ -177,6 +177,7 @@ const stateWeakMap = new WeakMap<Stateful<State>, State>();
  */
 const createStateful: StatefulFactory = createEvented
 	.mixin({
+		className: 'Stateful',
 		mixin: {
 			get state(this: Stateful<State>): State {
 				return stateWeakMap.get(this);

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1516,21 +1516,21 @@ registerSuite({
 			if (!hasConfigurableName()) {
 				this.skip('Functions do not have configurable names');
 			}
-			const createFoo = compose({
+			const createFoo = compose('Foo', {
 				foo: 'foo'
-			}, function () {}, 'Foo');
+			}, function () {});
 			assert.deepEqual(getInitFunctionNames(createFoo), [ 'initFoo' ]);
-			const createBar = compose({
+			const createBar = compose('Bar', {
 				bar: 1
-			}, function () {}, 'Bar');
+			}, function () {});
 			const createFooBar = createFoo.mixin(createBar);
 			assert.deepEqual(getInitFunctionNames(createFooBar), [ 'initFoo', 'initBar' ]);
 			const createFooBarMixin = createFoo.mixin({
+				className: 'FooBar',
 				mixin: createBar,
 				initialize(instance) {
 					instance.bar = 3;
-				},
-				className: 'FooBar'
+				}
 			});
 			assert.deepEqual(getInitFunctionNames(createFooBarMixin), [ 'initFoo', 'initBar', 'mixinFooBar' ]);
 			const createFooBarNoClassName = createBar.mixin({
@@ -1541,10 +1541,10 @@ registerSuite({
 			});
 			assert.deepEqual(getInitFunctionNames(createFooBarNoClassName), [ 'initBar', 'initFoo', 'mixinFoo' ]);
 			const createFooNamed = createFoo.mixin({
+				className: 'FooNamed',
 				initialize(instance) {
 					instance.foo = 'bar';
-				},
-				className: 'FooNamed'
+				}
 			});
 			assert.deepEqual(getInitFunctionNames(createFooNamed), [ 'initFoo', 'mixinFooNamed' ]);
 		},
@@ -1553,15 +1553,15 @@ registerSuite({
 			if (!hasConfigurableName()) {
 				this.skip('Functions do not have configurable names');
 			}
-			const createFoo = compose({}, 'Foo');
+			const createFoo = compose('Foo', {});
 			const foo = createFoo();
 			assert.strictEqual((<any> foo).toString(), '[object Foo]');
 			const createFooBar = createFoo
 				.mixin({
+					className: 'FooBar',
 					mixin: {
 						bar: 1
-					},
-					className: 'FooBar'
+					}
 				});
 			const foobar = createFooBar();
 			assert.strictEqual((<any> foobar).toString(), '[object FooBar]');
@@ -1573,6 +1573,19 @@ registerSuite({
 				});
 			const foobarnoname = createFooBarNoName();
 			assert.strictEqual((<any> foobarnoname).toString(), '[object Foo]');
+			const createOverrideClassName = createFoo
+				.mixin({
+					className: 'OverrideClassName'
+				});
+			const overrideClassName = createOverrideClassName();
+			assert.strictEqual((<any> overrideClassName).toString(), '[object OverrideClassName]');
+			const createBar = compose({})
+				.mixin({
+					className: 'Bar',
+					mixin: createFoo
+				});
+			const bar = createBar();
+			assert.strictEqual((<any> bar).toString(), '[object Bar]');
 		}
 	}
 });

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1549,6 +1549,43 @@ registerSuite({
 			assert.deepEqual(getInitFunctionNames(createFooNamed), [ 'initFoo', 'mixinFooNamed' ]);
 		},
 
+		'getInitFunctionNames does no throw on environments with non-configurable names'(this: any) {
+			if (hasConfigurableName()) {
+				this.skip('Only valid for non-configurable function name environments');
+			}
+			const createFoo = compose('Foo', {
+				foo: 'foo'
+			}, function () {});
+			assert.strictEqual((<any> getInitFunctionNames(createFoo)).length, 1);
+			const createBar = compose('Bar', {
+				bar: 1
+			}, function () {});
+			const createFooBar = createFoo.mixin(createBar);
+			assert.strictEqual((<any> getInitFunctionNames(createFooBar)), 2);
+			const createFooBarMixin = createFoo.mixin({
+				className: 'FooBar',
+				mixin: createBar,
+				initialize(instance) {
+					instance.bar = 3;
+				}
+			});
+			assert.strictEqual((<any> getInitFunctionNames(createFooBarMixin)), 3);
+			const createFooBarNoClassName = createBar.mixin({
+				mixin: createFoo,
+				initialize(instance) {
+					instance.foo = 'bar';
+				}
+			});
+			assert.strictEqual((<any> getInitFunctionNames(createFooBarNoClassName)), 3);
+			const createFooNamed = createFoo.mixin({
+				className: 'FooNamed',
+				initialize(instance) {
+					instance.foo = 'bar';
+				}
+			});
+			assert.strictEqual((<any> getInitFunctionNames(createFooNamed)), 2);
+		},
+
 		'instance to string'(this: any) {
 			if (!hasConfigurableName()) {
 				this.skip('Functions do not have configurable names');

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1590,6 +1590,28 @@ registerSuite({
 				.extend('ExtendedBar', {});
 			const extendedBar = createExtendedBar();
 			assert.strictEqual((<any> extendedBar).toString(), '[object ExtendedBar]');
+		},
+
+		'unlabelled factories use "Compose"'(this: any) {
+			if (!hasConfigurableName()) {
+				this.skip('Functions do not have configurable names');
+			}
+			const createEmpty = compose({});
+			const empty = createEmpty();
+			assert.strictEqual((<any> empty).toString(), '[object Compose]');
+		},
+
+		'factories "inherit" names when not supplied'(this: any) {
+			if (!hasConfigurableName()) {
+				this.skip('Functions do not have configurable names');
+			}
+			const createStatic = compose('Static', {})
+				.static({
+					foo: 'bar'
+				});
+
+			const s = createStatic();
+			assert.strictEqual((<any> s).toString(), '[object Static]');
 		}
 	}
 });

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1586,6 +1586,10 @@ registerSuite({
 				});
 			const bar = createBar();
 			assert.strictEqual((<any> bar).toString(), '[object Bar]');
+			const createExtendedBar = createBar
+				.extend('ExtendedBar', {});
+			const extendedBar = createExtendedBar();
+			assert.strictEqual((<any> extendedBar).toString(), '[object ExtendedBar]');
 		}
 	}
 });

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1561,7 +1561,7 @@ registerSuite({
 				bar: 1
 			}, function () {});
 			const createFooBar = createFoo.mixin(createBar);
-			assert.strictEqual((<any> getInitFunctionNames(createFooBar)), 2);
+			assert.strictEqual((<any> getInitFunctionNames(createFooBar)).length, 2);
 			const createFooBarMixin = createFoo.mixin({
 				className: 'FooBar',
 				mixin: createBar,
@@ -1569,21 +1569,21 @@ registerSuite({
 					instance.bar = 3;
 				}
 			});
-			assert.strictEqual((<any> getInitFunctionNames(createFooBarMixin)), 3);
+			assert.strictEqual((<any> getInitFunctionNames(createFooBarMixin)).length, 3);
 			const createFooBarNoClassName = createBar.mixin({
 				mixin: createFoo,
 				initialize(instance) {
 					instance.foo = 'bar';
 				}
 			});
-			assert.strictEqual((<any> getInitFunctionNames(createFooBarNoClassName)), 3);
+			assert.strictEqual((<any> getInitFunctionNames(createFooBarNoClassName)).length, 3);
 			const createFooNamed = createFoo.mixin({
 				className: 'FooNamed',
 				initialize(instance) {
 					instance.foo = 'bar';
 				}
 			});
-			assert.strictEqual((<any> getInitFunctionNames(createFooNamed)), 2);
+			assert.strictEqual((<any> getInitFunctionNames(createFooNamed)).length, 2);
 		},
 
 		'instance to string'(this: any) {

--- a/tests/unit/mixins/createDestroyable.ts
+++ b/tests/unit/mixins/createDestroyable.ts
@@ -56,5 +56,9 @@ registerSuite({
 		assert.isFalse(isDestroyable(undefined));
 		assert.isFalse(isDestroyable(/foo/));
 		assert.isFalse(isDestroyable(() => { }));
+	},
+	'toString()'() {
+		const destroyable = createDestroyable();
+		assert.strictEqual((<any> destroyable).toString(), '[object Destroyable]');
 	}
 });

--- a/tests/unit/mixins/createEvented.ts
+++ b/tests/unit/mixins/createEvented.ts
@@ -209,5 +209,9 @@ registerSuite({
 
 			assert.deepEqual(eventStack, [ 'foo', 'bar', 'bar' ]);
 		}
+	},
+	'toString()'() {
+		const evented = createEvented();
+		assert.strictEqual((<any> evented).toString(), '[object Evented]');
 	}
 });

--- a/tests/unit/mixins/createStateful.ts
+++ b/tests/unit/mixins/createStateful.ts
@@ -414,5 +414,9 @@ registerSuite({
 			assert.deepEqual(stateful.state, { foo: 'qat' });
 			assert.strictEqual(count, 2, 'listener called again');
 		}
+	},
+	'toString()'() {
+		const stateful: any = createStateful();
+		assert.strictEqual(stateful.toString(), '[object Stateful]');
 	}
 });


### PR DESCRIPTION
**Type:** feature

**Related Issue:** #63

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [x] The PR increases or maintains the overall unit test coverage percentage
- [x] The code is ready to be merged

**Description:** 

This is a WIP PR to make it easier to debug compose factories.

Currently, this PR allows for naming of classes, which in turn can influence the names of the initialization functions.

On composition, you can supply a class name.  You can also supply an alternative class name when mixin in.  So for example:

``` typescript
import compose, { getInitFunctionNames } from 'dojo-compose/compose';

const createFoo = compose({
    foo: 'foo'
}, (instance) => {
    /* init logic */
}, 'Foo');

console.log(getInitFunctionNames(createFoo)); // [ 'initFoo' ]
const foo = createFoo();
console.log((<any> foo).toString()); // '[object Foo]'

const createFooBar = createFoo
    .mixin({
        mixin: {
            bar: 1
        },
        initialize(instance) {
            instance.bar = 2;
        },
        className: 'FooBar'
    });

console.log(getInitFunctionNames(createFooBar)); // [ 'initFoo', 'mixinFooBar' ]
const foobar = createFooBar();
console.log((<any> foobar).toString()); // '[object FooBar]'
```

Depending on the environment, you may see instances logged with the class name as well, as the PR attempts to rename the factory function and the initialization functions with some sort of meaningful name.

These are all opt-in, in the sense that if the names are omitted, `compose` will still have its previous behaviour, which would generally produce everything labelled as `factory`.
