### PR TITLE
Do not copy .constructor on factory mixin

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -104,7 +104,7 @@ function copyProperties(target: any, ...sources: any[]) {
 			target,
 			Object.getOwnPropertyNames(source).reduce(
 				(descriptors: PropertyDescriptorMap, key: string) => {
-					if (key !== 'toString') { /* copying toString from a mixin causes issues */
+					if (key !== 'toString' && key !== 'constructor') { /* don't copy toString or constructor */
 						const sourceDescriptor = Object.getOwnPropertyDescriptor(source, key);
 						const sourceValue = sourceDescriptor && sourceDescriptor.value;
 						const targetDescriptor = Object.getOwnPropertyDescriptor(target, key);

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -368,6 +368,28 @@ registerSuite({
 				'Own property names did not include non-enumerable property');
 		},
 
+		'constructor property not copied'() {
+			function constructor() {
+				throw new Error('Should not be copied');
+			}
+			const composeObj = { constructor };
+			const createFoo = compose({
+				foo: 'bar'
+			}).extend(composeObj);
+			assert.notStrictEqual(createFoo.prototype.constructor, constructor);
+		},
+
+		'toString property not copied'() {
+			function toString() {
+				throw new Error('Should not be copied');
+			}
+			const composeObj = { toString };
+			const createFoo = compose({
+				foo: 'bar'
+			}).extend(composeObj);
+			assert.notStrictEqual(createFoo.prototype.toString, toString);
+		},
+
 		'array prototype property': function() {
 			const arr = [ function () { return 'foo'; }, function () { return 'bar'; } ];
 			const createFoo = compose({ arr });


### PR DESCRIPTION
**Type:** feature

**Related Issue:** #13 

Please review this checklist before submitting your PR:
- [X] There is a related issue
- [X] All contributors have signed a CLA
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [X] The code passes the CI tests
- [X] Unit or Functional tests are included in the PR
- [X] The PR increases or maintains the overall unit test coverage percentage
- [X] The code is ready to be merged

Do not copy `.constructor` when mixing into the prototype of a factory.
