### PR TITLE
Created mixin changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ factory descriptor is required, the `factoryDescriptor` method can be overridden
 ### Merging of Arrays
 
 When mixing in or extending classes which contain array literals as a value of a property, `compose` will merge these values
-instead of over writting, which it does with other value types.
+instead of over writing, which it does with other value types.
 
 For example, if I have an array of strings in my original class, and provide a mixin which shares the same property that is
 also an array, those will get merged:

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1211,8 +1211,8 @@ export interface ComposeCreatedMixin<Target, T, O, S> {
 
 	aspect(advice: AspectAdvice): this;
 
-	init(name: string, init: ComposeInitializationFunction<Target & T, O>): this;
-	init(init: ComposeInitializationFunction<Target & T, O>): this;
+	init<P>(name: string, init: ComposeInitializationFunction<Target & T, P>): ComposeCreatedMixin<Target, T, O & P, S>;
+	init<P>(init: ComposeInitializationFunction<Target & T, P>): ComposeCreatedMixin<Target, T, O & P, S>;
 
 	// target<U>(target: ComposeMixinItem<U, any>): ComposeCreatedMixin<Target & U, T, O>;
 }
@@ -1291,7 +1291,7 @@ function createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | C
 }
 
 export interface Compose {
-	createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, T & Target, O, S>;
+	createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, O>): ComposeCreatedMixin<Target, T & Target, O, S>;
 }
 function execute<T, O, U, P, S>(_base: ComposeFactory<T, O>, toMixin: ComposeCreatedMixin<T, U, P, S>): ComposeFactory<T & U, O & P> & S {
 	let base: { [key: string]: Function } = <any> _base,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -239,6 +239,8 @@ function factoryDescriptor<T, O, U, P>(mixin: ComposeFactory<U, P>): ComposeMixi
  */
 const doFactoryDescriptor = rebase(factoryDescriptor);
 
+const doCreatedMixin = rebase(createdMixin);
+
 /**
  * A set of functions that are used to decorate the compose factories
  */
@@ -253,7 +255,8 @@ const staticMethods = {
 	around: doAround,
 	aspect: doAspect,
 	factoryDescriptor: doFactoryDescriptor,
-	static: doStatic
+	static: doStatic,
+	createdMixin: doCreatedMixin
 };
 
 /**
@@ -1119,6 +1122,100 @@ function aspect<T, O>(base: ComposeFactory<T, O>, advice: AspectAdvice): Compose
 	});
 }
 
+interface ComposeCreatedMixin<T, O> extends ComposeFactory<T, O> {
+	execute<U, P>(toMixin: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+}
+
+class Mixin {
+	private _calls: ([string, any[]])[];
+	private _initFunction: ComposeInitializationFunction<any, any>;
+
+	constructor(initFunction?: ComposeInitializationFunction<any, any>) {
+		this._calls = [];
+		this._initFunction = initFunction;
+	}
+
+	execute<U, P>(toMixin: ComposeFactory<any, any>): ComposeFactory<any, any> {
+		let base: { [key: string]: Function } = <any> this,
+			calls = this._calls;
+		for (let i = 0; i < calls.length; i++) {
+			let [fn, args] = calls[i];
+			base[fn].apply(base, args);
+		}
+		return base as any;
+	}
+
+	create() {
+		// no-op
+		return this;
+	}
+
+	static(...args: any[]) {
+		this._calls.push(['static', args]);
+		return this;
+	}
+
+	extend(...args: any[]) {
+		this._calls.push(['extend', args]);
+		return this;
+	}
+
+	mixin(...args: any[]) {
+		this._calls.push(['mixin', args]);
+		return this;
+	}
+
+	overlay(...args: any[]) {
+		this._calls.push(['overlay', args]);
+		return this;
+	}
+
+	from(...args: any[]) {
+		this._calls.push(['from', args]);
+		return this;
+	}
+
+	before(...args: any[]) {
+		this._calls.push(['before', args]);
+		return this;
+	}
+
+	after(...args: any[]) {
+		this._calls.push(['after', args]);
+		return this;
+	}
+
+	around(...args: any[]) {
+		this._calls.push(['around', args]);
+		return this;
+	}
+
+	aspect(...args: any[]) {
+		this._calls.push(['extend', args]);
+		return this;
+	}
+}
+
+function createMixin<T, O>(initFunction?: ComposeInitializationFunction<T, O>): ComposeCreatedMixin<T, O> {
+	let mixin: any = new Mixin(initFunction);
+	return mixin;
+}
+
+export interface Compose {
+	createMixin<T, O>(initFunction?: ComposeInitializationFunction<T, O>): ComposeCreatedMixin<T, O>;
+}
+
+function createdMixin<T, O, U, P>(
+	base: ComposeFactory<T, O>,
+	toMixin: ComposeCreatedMixin<U, P>
+): ComposeFactory<T & U, O & P> {
+	return toMixin.execute(base);
+}
+
+export interface ComposeFactory<T, O> {
+	createdMixin<U, P>(toMixin: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+}
+
 /* Creation API */
 
 export interface ComposeFactory<T, O extends Options> extends ComposeMixinable<T, O> {
@@ -1270,7 +1367,8 @@ assign(compose, {
 	before,
 	after,
 	around,
-	aspect
+	aspect,
+	createMixin
 });
 
 export default compose;

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1136,8 +1136,11 @@ class Mixin {
 	}
 
 	execute<U, P>(toMixin: ComposeFactory<any, any>): ComposeFactory<any, any> {
-		let base: { [key: string]: Function } = <any> this,
+		let base: { [key: string]: Function } = <any> toMixin,
 			calls = this._calls;
+		if (this._initFunction) {
+			base = <any> create(toMixin, this._initFunction);
+		}
 		for (let i = 0; i < calls.length; i++) {
 			let [fn, args] = calls[i];
 			base[fn].apply(base, args);

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1285,13 +1285,13 @@ class Mixin {
 	// }
 }
 
-function createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, T & Target, O, S> {
+function createMixin<Target, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, Target, O, S> {
 	let mixin: any = new Mixin();
 	return mixin;
 }
 
 export interface Compose {
-	createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, O>): ComposeCreatedMixin<Target, T & Target, O, S>;
+	createMixin<Target, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, O>): ComposeCreatedMixin<Target, Target, O, S>;
 }
 function execute<T, O, U, P, S>(_base: ComposeFactory<T, O>, toMixin: ComposeCreatedMixin<T, U, P, S>): ComposeFactory<T & U, O & P> & S {
 	let base: { [key: string]: Function } = <any> _base,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1276,10 +1276,6 @@ class Mixin {
 		this._calls.push([ 'init', args ]);
 		return this;
 	}
-
-	// target(...args: any[]) {
-	// 	return this;
-	// }
 }
 
 function createMixin<Target, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, Target, O, S> {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,4 +1,3 @@
-import { deprecated } from '@dojo/core/instrument';
 import { assign } from '@dojo/core/lang';
 import { from as arrayFrom, includes } from '@dojo/shim/array';
 import WeakMap from '@dojo/shim/WeakMap';
@@ -178,9 +177,9 @@ function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any
  * @param factory The factory that the array of function names should be returned for
  */
 export function getInitFunctionNames(factory: ComposeFactory<any, any>): string[] | undefined {
-	const initFns = privateFactoryData.get(factory).initFns;
-	if (initFns) {
-		return initFns.map((fn) => (<any> fn).name);
+	const factoryData = privateFactoryData.get(factory);
+	if (factoryData) {
+		return factoryData.initFns.map((fn) => (<any> fn).name);
 	}
 }
 
@@ -189,7 +188,6 @@ export function getInitFunctionNames(factory: ComposeFactory<any, any>): string[
 /**
  * Perform an extension of a class
  *
- * @deprecated
  */
 const doExtend = rebase(extend);
 
@@ -218,6 +216,8 @@ const doAspect = rebase(aspect);
  */
 const doStatic = rebase(_static);
 
+const doInit = rebase(init);
+
 /**
  * Take a mixin and return a factory descriptor for the mixin
  *
@@ -232,20 +232,17 @@ function factoryDescriptor<T, O, U, P>(mixin: ComposeFactory<U, P>): ComposeMixi
 		mixin,
 		className: mixin.name
 	};
-};
+}
 
 /**
  * Generate a factory descriptor for a class
  */
 const doFactoryDescriptor = rebase(factoryDescriptor);
-
-const doCreatedMixin = rebase(createdMixin);
-
 /**
  * A set of functions that are used to decorate the compose factories
  */
 const staticMethods = {
-	extend: doExtend, /* DEPRECATED */
+	extend: doExtend,
 	mixin: doMixin,
 	override: doOverride,
 	overlay: doOverlay,
@@ -256,7 +253,7 @@ const staticMethods = {
 	aspect: doAspect,
 	factoryDescriptor: doFactoryDescriptor,
 	static: doStatic,
-	createdMixin: doCreatedMixin
+	init: doInit
 };
 
 /**
@@ -431,7 +428,7 @@ function createFactory<T, U, O>(options: FactoryOptions<T, U, O, any>): ComposeF
 		DEFAULT_FACTORY_LABEL;
 	assignFactoryName(factory, className);
 
-	/* freeze the factory, so it cannot be accidently modified */
+	/* freeze the factory, so it cannot be accidentally modified */
 	Object.freeze(factory);
 
 	return factory as ComposeFactory<any, any>;
@@ -496,7 +493,6 @@ export interface ComposeFactory<T, O extends Options> extends ComposeMixinable<T
 	/**
 	 * Extend the factory prototype with the supplied object literal, class, or factory
 	 *
-	 * @deprecated
 	 * @param extension The object literal, class or factory to extend
 	 * @template T The original type of the factory
 	 * @template U The type of the extension
@@ -514,7 +510,6 @@ export interface Compose {
 	 * Extend a compose factory prototype with the supplied object literal, class, or
 	 * factory.
 	 *
-	 * @deprecated
 	 * @param base The base compose factory to extend
 	 * @param extension The object literal, class or factory that is the extension
 	 * @template T The base type of the factory
@@ -531,14 +526,12 @@ export interface Compose {
 /**
  * The internal implementation of extending a compose factory
  *
- * @deprecated
  * @param base The base compose factory that is being extended
  * @param extension The extension to apply to the compose factory
  */
 function extend<T, O, U, P>(base: ComposeFactory<T, O>, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 function extend<T, O, U, P>(base: ComposeFactory<T, O>, className: string, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 function extend<O>(base: ComposeFactory<any, O>, className: any, extension?: any): ComposeFactory<any, O> {
-	deprecated({ message: 'This function will be removed, use "override" instead.', name: 'extend' });
 	if (typeof className !== 'string') {
 		extension = className;
 		className = undefined;
@@ -630,6 +623,55 @@ function override<T, O>(baseFactory: ComposeFactory<T, O>, className: any, prope
 	});
 }
 
+/* Init API */
+export interface ComposeFactory<T, O extends Options> extends ComposeMixinable<T, O> {
+	/**
+	 * Add an initialization function to the factory's chain
+	 *
+	 * @param name An optional name for the function for debugging purposes
+	 * @param init The initialization function
+	 */
+	init(name: string, init: ComposeInitializationFunction<T, O>): ComposeFactory<T, O>;
+	init(init: ComposeInitializationFunction<T, O>): ComposeFactory<T, O>;
+}
+
+export interface Compose {
+	/**
+	 * Add the supplied initialization function to the factory's chain
+	 *
+	 * @param name Optional name for the init function
+	 * @param base The base compose factory
+	 * @param init The initialization function
+	 */
+	init<T, O>(name: string, base: ComposeFactory<T, O>, init: ComposeInitializationFunction<T, O>): ComposeFactory<T, O>;
+	init<T, O>(base: ComposeFactory<T, O>, init: ComposeInitializationFunction<T, O>): ComposeFactory<T, O>;
+}
+
+/**
+ * The internal implementation of adding an initialization functoin
+ *
+ * @param base The base compose factory
+ * @param className The optional name for the init function
+ * @param initFunction The initialization function
+ */
+function init<T, O>(base: ComposeFactory<T, O>, className: any, initFunction: ComposeInitializationFunction<T, O>): ComposeFactory<T, O> {
+	if (typeof className !== 'string') {
+		initFunction = className;
+		className = undefined;
+	}
+
+	/* Label the initFunction */
+	if (initFunction && className) {
+		assignFunctionName(initFunction, `init${className}`);
+	}
+
+	return createFactory({
+		className,
+		factories: [ base ],
+		initFunction
+	});
+}
+
 /* Overlay API */
 
 export interface OverlayFunction<T> {
@@ -705,7 +747,6 @@ export interface AspectAdvice {
 }
 
 /* Mixin API */
-
 /**
  * Either a class, object literal, or a factory
  */
@@ -754,8 +795,10 @@ export interface ComposeFactory<T, O extends Options> extends ComposeMixinable<T
 	 *
 	 * @param mixin An object literal that describes what to mixin
 	 */
+	mixin<U, P, S>(mixin: ComposeCreatedMixin<T, U, P, S>): ComposeFactory<T & U, O & P> & S;
 	mixin<U, P>(mixin: ComposeMixinable<U, P>): ComposeFactory<T & U, O & P>;
 	mixin<U, P>(mixin: ComposeMixinDescriptor<T, O, U, P>): ComposeFactory<T & U, O & P>;
+	mixin<U, P, S>(mixin: ComposeCreatedMixin<T, U, P, S>): ComposeFactory<T & U, O & P> & S;
 }
 
 export interface Compose {
@@ -773,6 +816,10 @@ export interface Compose {
 		base: ComposeFactory<T, O>,
 		mixin: ComposeMixinDescriptor<T, O, U, P>
 	): ComposeFactory<T & U, O & P>;
+	mixin<T, O, U, P, S>(
+		base: ComposeFactory<T, O>,
+		mixin: ComposeCreatedMixin<T, U, P, S>
+	): ComposeFactory<T & U, O & P> & S;
 }
 
 /**
@@ -832,54 +879,66 @@ function isComposeMixinable(value: any): value is ComposeMixinable<any, any> {
 }
 
 /**
+ * A custom type guard that determines if a value is a ComposeCreatedMixin
+ */
+function isCreatedMixin(value: any): value is ComposeCreatedMixin<any, any, any, any> {
+	return value instanceof Mixin;
+}
+
+/**
  * The internal implementation of mixin in values into a compose factory
  *
  * @param base The base compose factory that is the target for being mixed in
+ * @param name Optional name parameter
  * @param toMixin The value to be mixed in
  */
-function mixin<T, O, U, P>(
-	base: ComposeFactory<T, O>,
-	toMixin: ComposeMixinable<U, P> | ComposeMixinDescriptor<T, O, U, P>
-): ComposeFactory<T & U, O & P> {
-	/* ensure we are dealing with a mixinDescriptor */
-	const mixinDescriptor = isComposeMixinable(toMixin) ? toMixin.factoryDescriptor() : toMixin;
+function mixin<T, O, U, P, S>(
+	base: any,
+	toMixin: ComposeMixinable<U, P> | ComposeMixinDescriptor<T, O, U, P> | ComposeCreatedMixin<T, U, P, S>
+): ComposeFactory<T & U, O & P> | (ComposeFactory<T & U, O & P> & S) {
+	if (isCreatedMixin(toMixin)) {
+		return execute(base, toMixin) as (ComposeFactory<T & U, O & P> & S);
+	} else {
+		/* ensure we are dealing with a mixinDescriptor */
+		const mixinDescriptor = isComposeMixinable(toMixin) ? toMixin.factoryDescriptor() : toMixin;
 
-	/* destructure out most of the factory creation options */
-	const { mixin, initialize: initFunction, aspectAdvice, className } = mixinDescriptor;
+		/* destructure out most of the factory creation options */
+		const { mixin, initialize: initFunction, aspectAdvice, className } = mixinDescriptor;
 
-	/* we will at least be using the base factory to create the new one */
-	const factories: ComposeFactory<any, any>[] = [ base ];
-	let proto: any;
+		/* we will at least be using the base factory to create the new one */
+		const factories: ComposeFactory<any, any>[] = [ base ];
+		let proto: any;
 
-	/* if mixin is a compose factory, we will pass it as a factory used to create the new factory */
-	if (isComposeFactory(mixin)) {
-		factories.push(mixin);
-	}
-	/* otherwise we are dealing with a prototype based mixin */
-	else {
-		/* of which, we can have a constructor function/class, or an object literal (or undefined) */
-		proto = typeof mixin === 'function' ? mixin.prototype : mixin;
-	}
+		/* if mixin is a compose factory, we will pass it as a factory used to create the new factory */
+		if (isComposeFactory(mixin)) {
+			factories.push(mixin);
+		}
+		/* otherwise we are dealing with a prototype based mixin */
+		else {
+			/* of which, we can have a constructor function/class, or an object literal (or undefined) */
+			proto = typeof mixin === 'function' ? mixin.prototype : mixin;
+		}
 
-	/* convert the advice, if any, to the format used by createFactory */
-	const advice = aspectAdviceToAdviceMap(aspectAdvice);
+		/* convert the advice, if any, to the format used by createFactory */
+		const advice = aspectAdviceToAdviceMap(aspectAdvice);
 
-	/* label the initFn */
-	if (initFunction) {
-		assignFunctionName(
+		/* label the initFn */
+		if (initFunction) {
+			assignFunctionName(
+				initFunction,
+				`mixin${className || (isComposeFactory(mixin) && mixin.name) || base.name}`
+			);
+		}
+
+		/* return the newly created factory */
+		return createFactory({
+			advice,
+			factories,
 			initFunction,
-			`mixin${className || (isComposeFactory(mixin) && mixin.name) || base.name}`
-		);
+			className,
+			proto
+		}) as ComposeFactory<T & U, O & P>;
 	}
-
-	/* return the newly created factory */
-	return createFactory({
-		advice,
-		factories,
-		initFunction,
-		className,
-		proto
-	}) as ComposeFactory<T & U, O & P>;
 }
 
 export interface ComposeFactory<T, O extends Options> extends ComposeMixinable<T, O> {
@@ -1122,101 +1181,128 @@ function aspect<T, O>(base: ComposeFactory<T, O>, advice: AspectAdvice): Compose
 	});
 }
 
-interface ComposeCreatedMixin<T, O> extends ComposeFactory<T, O> {
-	execute<U, P>(toMixin: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+/**
+ * Provides essentially the same methods as a compose factory, but is not a callable function
+ */
+export interface ComposeCreatedMixin<Target, T, O, S> {
+	// created: Target;
+	extend<U>(extension: U | GenericClass<U>): ComposeCreatedMixin<Target, T & U, O, S>;
+	extend<U>(className: string, extension: U | GenericClass<U>): ComposeCreatedMixin<Target, T & U, O, S>;
+	extend<U, P>(extension: ComposeFactory<U, P>): ComposeCreatedMixin<Target, T & U, O & P, S>;
+	extend<U, P>(className: string, extension: ComposeFactory<U, P>): ComposeCreatedMixin<Target, T & U, O & P, S>;
+
+	override(properties: any): this;
+	override(className: string, properties: any): this;
+
+	static<Z>(staticProperties: Z): ComposeCreatedMixin<Target, T, O, S & Z>;
+
+	overlay(overlayFunction: OverlayFunction<T>): this;
+	mixin<U, P>(mixin: ComposeMixinable<U, P>): ComposeCreatedMixin<Target, T & U, O & P, S>;
+	mixin<U, P>(mixin: ComposeMixinDescriptor<T, O, U, P>): ComposeCreatedMixin<Target, T & U, O & P, S>;
+	mixin<U, P, Z>(mixin: ComposeCreatedMixin<T, U, P, Z>): ComposeCreatedMixin<Target, T & U, O & P, S & Z>;
+
+	from(base: GenericClass<any> | ComposeFactory<any, any>, method: string): this;
+
+	before(method: string, advice: BeforeAdvice): this;
+
+	after<P>(method: string, advice: AfterAdvice<P>): this;
+
+	around<P>(method: string, advice: AroundAdvice<P>): this;
+
+	aspect(advice: AspectAdvice): this;
+
+	init(name: string, init: ComposeInitializationFunction<Target & T, O>): this;
+	init(init: ComposeInitializationFunction<Target & T, O>): this;
+
+	// target<U>(target: ComposeMixinItem<U, any>): ComposeCreatedMixin<Target & U, T, O>;
 }
 
 class Mixin {
-	private _calls: ([string, any[]])[];
-	private _initFunction: ComposeInitializationFunction<any, any>;
+	_calls: ([string, any[]])[];
+	created: any = true;
 
-	constructor(initFunction?: ComposeInitializationFunction<any, any>) {
+	constructor() {
 		this._calls = [];
-		this._initFunction = initFunction;
-	}
-
-	execute<U, P>(toMixin: ComposeFactory<any, any>): ComposeFactory<any, any> {
-		let base: { [key: string]: Function } = <any> toMixin,
-			calls = this._calls;
-		if (this._initFunction) {
-			base = <any> create(toMixin, this._initFunction);
-		}
-		for (let i = 0; i < calls.length; i++) {
-			let [fn, args] = calls[i];
-			base[fn].apply(base, args);
-		}
-		return base as any;
-	}
-
-	create() {
-		// no-op
-		return this;
 	}
 
 	static(...args: any[]) {
-		this._calls.push(['static', args]);
+		this._calls.push([ 'static', args ]);
 		return this;
 	}
 
 	extend(...args: any[]) {
-		this._calls.push(['extend', args]);
+		this._calls.push([ 'extend', args ]);
 		return this;
 	}
 
 	mixin(...args: any[]) {
-		this._calls.push(['mixin', args]);
+		this._calls.push([ 'mixin', args ]);
 		return this;
 	}
 
 	overlay(...args: any[]) {
-		this._calls.push(['overlay', args]);
+		this._calls.push([ 'overlay', args ]);
+		return this;
+	}
+
+	override(...args: any[]) {
+		this._calls.push([ 'override', args ]);
 		return this;
 	}
 
 	from(...args: any[]) {
-		this._calls.push(['from', args]);
+		this._calls.push([ 'from', args ]);
 		return this;
 	}
 
 	before(...args: any[]) {
-		this._calls.push(['before', args]);
+		this._calls.push([ 'before', args ]);
 		return this;
 	}
 
 	after(...args: any[]) {
-		this._calls.push(['after', args]);
+		this._calls.push([ 'after', args ]);
 		return this;
 	}
 
 	around(...args: any[]) {
-		this._calls.push(['around', args]);
+		this._calls.push([ 'around', args ]);
 		return this;
 	}
 
 	aspect(...args: any[]) {
-		this._calls.push(['extend', args]);
+		this._calls.push([ 'aspect', args ]);
 		return this;
 	}
+
+	init(...args: any[]) {
+		this._calls.push([ 'init', args ]);
+		return this;
+	}
+
+	// target(...args: any[]) {
+	// 	return this;
+	// }
 }
 
-function createMixin<T, O>(initFunction?: ComposeInitializationFunction<T, O>): ComposeCreatedMixin<T, O> {
-	let mixin: any = new Mixin(initFunction);
+function createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, T & Target, O, S> {
+	let mixin: any = new Mixin();
 	return mixin;
 }
 
 export interface Compose {
-	createMixin<T, O>(initFunction?: ComposeInitializationFunction<T, O>): ComposeCreatedMixin<T, O>;
+	createMixin<Target, T, O, S>(target?: GenericClass<Target> | Target | ComposeFactory<Target, any>): ComposeCreatedMixin<Target, T & Target, O, S>;
 }
+function execute<T, O, U, P, S>(_base: ComposeFactory<T, O>, toMixin: ComposeCreatedMixin<T, U, P, S>): ComposeFactory<T & U, O & P> & S {
+	let base: { [key: string]: Function } = <any> _base,
+		mixin = <Mixin> <any> toMixin,
+		calls = mixin._calls;
 
-function createdMixin<T, O, U, P>(
-	base: ComposeFactory<T, O>,
-	toMixin: ComposeCreatedMixin<U, P>
-): ComposeFactory<T & U, O & P> {
-	return toMixin.execute(base);
-}
-
-export interface ComposeFactory<T, O> {
-	createdMixin<U, P>(toMixin: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
+	for (let i = 0; i < calls.length; i++) {
+		let [fn, args] = calls[i];
+		base = base[fn].apply(base, args);
+	}
+	return base as any;
 }
 
 /* Creation API */
@@ -1275,7 +1361,7 @@ function create<T, O>(className: string, base: GenericClass<T> | T, initFunction
 function create<T, O, P>(base: ComposeFactory<T, O>, initFunction?: ComposeInitializationFunction<T, O & P>): ComposeFactory<T, O & P>;
 function create<T, O, P>(className: string, base: ComposeFactory<T, O>, initFunction?: ComposeInitializationFunction<T, O & P>): ComposeFactory<T, O & P>;
 function create<O>(className: any, base?: any, initFunction?: ComposeInitializationFunction<any, O>): ComposeFactory<any, any> {
-	/* disambugate arguments */
+	/* disambiguate arguments */
 	if (typeof className !== 'string') {
 		initFunction = base;
 		base = className;
@@ -1362,7 +1448,7 @@ const compose = create as Compose;
 assign(compose, {
 	create,
 	static: _static,
-	extend, /* DEPRECATED */
+	extend,
 	mixin,
 	override,
 	overlay,

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1185,7 +1185,6 @@ function aspect<T, O>(base: ComposeFactory<T, O>, advice: AspectAdvice): Compose
  * Provides essentially the same methods as a compose factory, but is not a callable function
  */
 export interface ComposeCreatedMixin<Target, T, O, S> {
-	// created: Target;
 	extend<U>(extension: U | GenericClass<U>): ComposeCreatedMixin<Target, T & U, O, S>;
 	extend<U>(className: string, extension: U | GenericClass<U>): ComposeCreatedMixin<Target, T & U, O, S>;
 	extend<U, P>(extension: ComposeFactory<U, P>): ComposeCreatedMixin<Target, T & U, O & P, S>;
@@ -1213,8 +1212,6 @@ export interface ComposeCreatedMixin<Target, T, O, S> {
 
 	init<P>(name: string, init: ComposeInitializationFunction<Target & T, P>): ComposeCreatedMixin<Target, T, O & P, S>;
 	init<P>(init: ComposeInitializationFunction<Target & T, P>): ComposeCreatedMixin<Target, T, O & P, S>;
-
-	// target<U>(target: ComposeMixinItem<U, any>): ComposeCreatedMixin<Target & U, T, O>;
 }
 
 class Mixin {

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1656,7 +1656,7 @@ registerSuite({
 			type Bar = { bar: string };
 			type BarOptions = { bar: string };
 			const bar: ComposeCreatedMixin<{foo: string}, {bar: string} & {bar: string}, {bar: string} & {}, {}>  =
-				compose.createMixin<{ foo: string }, Bar, BarOptions, {}>()
+				compose.createMixin<{ foo: string }, BarOptions, {}>()
 					.extend({
 						bar: 'bar'
 					}
@@ -1697,12 +1697,6 @@ registerSuite({
 		},
 
 		'add init function'() {
-			interface Bar {
-				bar: string;
-			}
-			interface Foo {
-				foo: string;
-			}
 			const createFoo = compose({
 				foo: 'original value'
 			}, function(instance, options?: { foo: string }) {
@@ -1713,7 +1707,7 @@ registerSuite({
 				.extend({
 					bar: 'bar'
 				})
-				.init((instance: Foo & Bar, options?: Foo & Bar) => {
+				.init((instance, options?: { foo: string, bar: string }) => {
 					if (options) {
 						instance.bar = options.bar;
 						instance.foo = options.foo;

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -644,6 +644,22 @@ registerSuite({
 			assert.strictEqual(fooBar.bar(), 'bar', 'Bar property not present');
 		},
 
+		'mixing in a mixin descriptor with init function'() {
+			const createFooBar = compose({
+					foo: 'foo'
+				})
+				.mixin({
+					mixin: { bar: 'bar' },
+					initialize(instance) {
+						instance.foo = instance.bar = 'foobar';
+					}
+				});
+
+			const fooBar = createFooBar();
+			assert.strictEqual(fooBar.foo, 'foobar', 'Didn\'t properly initialize foo property');
+			assert.strictEqual(fooBar.bar, 'foobar', 'Didn\'t properly initialize foo property');
+		},
+
 		'arrays': {
 			'present in base': function () {
 				const createFoo = compose({
@@ -1524,6 +1540,24 @@ registerSuite({
 					instance.foo = 'bar';
 				});
 			assert.deepEqual(getInitFunctionNames(createFooBarNoClassName), [ 'initBar', 'initFoo', 'initFooToo' ]);
+
+			const createFooBarMixinClassName = createBar
+				.mixin({
+					mixin: createFoo,
+					initialize(instance) {
+						instance.foo = 'bar';
+					}
+				});
+			assert.deepEqual(getInitFunctionNames(createFooBarMixinClassName), [ 'initBar', 'initFoo', 'mixinFoo' ]);
+
+			const createFooBarBaseClassName = createBar
+				.mixin({
+					mixin: { foo: 'foo' },
+					initialize(instance) {
+						instance.foo = 'bar';
+					}
+				});
+			assert.deepEqual(getInitFunctionNames(createFooBarBaseClassName), [ 'initBar', 'mixinBar' ]);
 		},
 
 		'getInitFunctionNames does no throw on environments with non-configurable names'(this: any) {
@@ -1643,8 +1677,9 @@ registerSuite({
 				});
 				// .target({foo: ''});
 			const createFooBar = compose({
-				foo: 'foo'
-			}).mixin(bar);
+					foo: 'foo'
+				})
+				.mixin(bar);
 
 			const fooBar = createFooBar();
 
@@ -1656,24 +1691,22 @@ registerSuite({
 			type Bar = { bar: string };
 			type BarOptions = { bar: string };
 			const bar: ComposeCreatedMixin<{foo: string}, {bar: string} & {bar: string}, {bar: string} & {}, {}>  =
-				compose.createMixin<{ foo: string }, BarOptions, {}>()
-					.extend({
-						bar: 'bar'
-					}
-			);
+				compose.createMixin<{ foo: string }, BarOptions, {}>().extend({ bar: 'bar' });
 
 			const createFooBar = compose({
-				foo: 'foo'
-			}).mixin(bar);
+					foo: 'foo'
+				})
+				.mixin(bar);
 			// Shouldn't compile, wrong target type but does. If
 			// target is added, then neither of these compile.
 			// const createBazBar = compose<{baz: string}, any>({
 			// 	baz: 'baz'
 			// }).mixin(bar);
 			const createBazBar = compose<{baz: string, foo: string}, any>({
-				baz: 'baz',
-				foo: 'foo'
-			}).mixin(bar);
+					baz: 'baz',
+					foo: 'foo'
+				})
+				.mixin(bar);
 			assert.strictEqual(createFooBar().bar, createBazBar().bar);
 			// assert.notOk(createBazBar().foo);
 		},
@@ -1739,10 +1772,10 @@ registerSuite({
 				foo: 'foo',
 				baz: ''
 			}, function(instance: any) {
-				// This runs first, and shouldn't expect anything from subsequent mixins
-				instance.bar = 3;
-				assert.strictEqual(instance.baz, '', 'instance contains baz');
-			})
+					// This runs first, and shouldn't expect anything from subsequent mixins
+					instance.bar = 3;
+					assert.strictEqual(instance.baz, '', 'instance contains baz');
+				})
 				.mixin(createBar)
 				.init(function(instance: any) {
 					// This runs third, as it's the new, optional initialize provided with the mixin
@@ -1809,32 +1842,6 @@ registerSuite({
 				.init(function(instance: { bar: string; baz: number }, options: { bar: string; baz: number }) {
 
 				});
-			/* Doesn't compile with new flow control typing, which maybe is a good thing? */
-			// createBar.mixin({
-			// 	initialize: function(instance: { baz: number }, options: { baz: number }) {
-
-			// 	},
-			// 	mixin: createBaz
-			// });
-			// createBar.mixin({
-			// 	initialize: function(instance: { bar: string }, options: { bar: string }) {
-
-			// 	},
-			// 	mixin: createBaz
-			// });
-			// Shouldn\'t compile
-			// const createBarBazIllegalInstanceType = createBar.mixin({
-			// initialize: function(instance: { baz: number; foo: number }) {
-			//
-			// },
-			// mixin: createBaz
-			// });
-			// const createBarBazIllegalOptionsType = createBar.mixin({
-			// initialize: function(instance: { baz: number; }, options: { baz: number; foo: string; }) {
-			//
-			// },
-			// mixin: createBaz
-			// });
 		},
 
 		'inferring init types'() {
@@ -1974,9 +1981,10 @@ registerSuite({
 				.from(Foo, 'foo');
 
 			const createFooBar = compose({
-				bar: 'qat',
-				foo: function (): string { return 'foo'; }
-			}).mixin(fromFooMixin);
+					bar: 'qat',
+					foo: function (): string { return 'foo'; }
+				})
+				.mixin(fromFooMixin);
 
 			const foobar = createFooBar();
 			assert.strictEqual(foobar.foo(), 'qat', 'Return from ".foo()" should equal "qat"');

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1758,6 +1758,32 @@ registerSuite({
 			assert.strictEqual(fooBar.bar, 'new value');
 		},
 
+		'infer options type'() {
+			const createFoo = compose<{ foo: string }, { foo: string }>({
+				foo: 'original value'
+			}, function(instance, options?: { foo: string }) {
+				instance.foo = 'initialized value';
+			});
+
+			const bar = compose.createMixin(createFoo)
+				.extend({
+					bar: 'bar'
+				})
+				.init((instance, options?) => {
+					if (options) {
+						instance.foo = options.foo;
+					}
+				});
+
+			const createFooBar = createFoo.mixin(bar);
+
+			const fooBar = createFooBar({
+				foo: 'final value'
+			});
+
+			assert.strictEqual(fooBar.foo, 'final value');
+		},
+
 		'compose factory and initialize'() {
 			const createBar = compose.createMixin()
 				.extend({

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1882,5 +1882,21 @@ registerSuite({
 			const s = createStatic();
 			assert.strictEqual((<any> s).toString(), '[object Static]');
 		}
+	},
+	createMixin: {
+		'basic': function() {
+			const bar = compose.createMixin()
+				.extend({
+					bar: 'bar'
+				});
+			const createFooBar = compose({
+				foo: 'foo'
+			}).createdMixin(bar);
+
+			const fooBar = createFooBar();
+
+			assert.strictEqual(fooBar.foo, 'foo');
+			assert.strictEqual(fooBar.bar, 'bar');
+		}
 	}
 });

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1703,7 +1703,13 @@ registerSuite({
 			interface Foo {
 				foo: string;
 			}
-			const bar = compose.createMixin()
+			const createFoo = compose({
+				foo: 'original value'
+			}, function(instance, options?: { foo: string }) {
+				instance.foo = 'initialized value';
+			});
+
+			const bar = compose.createMixin(createFoo)
 				.extend({
 					bar: 'bar'
 				})
@@ -1714,11 +1720,7 @@ registerSuite({
 					}
 				});
 
-			const createFooBar = compose({
-				foo: 'original value'
-			}, function(instance) {
-				instance.foo = 'initialized value';
-			}).mixin(bar);
+			const createFooBar = createFoo.mixin(bar);
 
 			const fooBar = createFooBar({
 				foo: 'final value',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.3",
+	"version": "2.1.5",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:
- [x] There is a related issue
- [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This contains a proposed API to resolve the mixin creation issue. 
@pottedmeat Had started work on an API for this and it would be used like this

``` typescript
const createdMixin = compose.createMixin()
  .extend(/* Normal compose extend */)
  .aspect(/* Normal aspect */)

const createFoo = compose({
  // Base class
}).createdMixin(createdMixin);
```

I made some further changes to this, and also included the addition of an `init` method that lets an initializer be added by itself at any point in the compose chain.

``` typescript
const mixin = compose.createMixin()
  .extend(/* Normal compose extend */)
  .aspect(/* Normal aspect */)
  .init(/* Initializer for type at this point in the chain */)

const createFoo = compose({
  // Base class
}).mixin(createdMixin);
```

Some notes on the API:
 `init` is also provided on the `ComposeFactory` API.
The `createMixin` call creates a `ComposeCreatedMixin`, which has generics for the type and the options, like the compose factory, as well as a `Target` generic that sets what it intends to mix into. Any init functions in the mixin chain are provided an instance of type `T & Target` because it is assumed they will be mixed into their target type. The `createMixin` function can also be passed an object, class, or factory which will be used as the `Target` type, so that it can be specified without passing all of the generics.

Right now the target type is not enforced. By uncommenting the `created` property in the interface type checking would be turned on. And there is also a `target` method commented out that will allow the target type to be inferred from a passed `ComposeMixinItem`(i.e. An object, class, or compose factory). The reason that it's currently commented out is that it does not allow being mixed into sub types of the target type. It doesn't seem like we would want to be that strict.

The mixin API is also limited as part of this PR, to only allow `ComposeFactory` types and `ComposeCreatedMixins`. The behavior for a `ComposeFactory` is the same as it has always been, and the idea behind removing the object argument option is that that would be better served as a `CreatedMixin` or just sequential calls on the factory.
Resolves #43, #71, #72
