### PR TITLE
Use Symbol.toStringTag instead of overwriting toString

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,6 +1,7 @@
 import { assign } from 'dojo-core/lang';
 import { from as arrayFrom, includes } from 'dojo-shim/array';
 import WeakMap from 'dojo-shim/WeakMap';
+import Symbol from 'dojo-shim/Symbol';
 import {
 	before as aspectBefore,
 	after as aspectAfter,
@@ -55,9 +56,9 @@ function setFunctionName(fn: Function, value: string): void {
 function setFactoryName(factory: Function, value: string): void {
 	if (typeof factory === 'function' && factory.prototype) {
 		setFunctionName(factory, value);
-		defineProperty(factory.prototype, 'toString', {
-			value() {
-				return `[object ${value}]`;
+		defineProperty(factory.prototype, <any> Symbol.toStringTag, {
+			get() {
+				return value;
 			},
 			configurable: true
 		});
@@ -104,7 +105,7 @@ function copyProperties(target: any, ...sources: any[]) {
 			target,
 			Object.getOwnPropertyNames(source).reduce(
 				(descriptors: PropertyDescriptorMap, key: string) => {
-					if (key !== 'toString' && key !== 'constructor') { /* don't copy toString or constructor */
+					if (key !== 'constructor') { /* don't copy constructor */
 						const sourceDescriptor = Object.getOwnPropertyDescriptor(source, key);
 						const sourceValue = sourceDescriptor && sourceDescriptor.value;
 						const targetDescriptor = Object.getOwnPropertyDescriptor(target, key);

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -1,0 +1,30 @@
+let _hasConfigurableName: boolean;
+
+/**
+ * Detects if functions have configurable names, some browsers that are not 100% ES2015
+ * compliant do not.
+ */
+export function hasConfigurableName(): boolean {
+	if (_hasConfigurableName !== undefined) {
+		return _hasConfigurableName;
+	}
+	const nameDescriptor = Object.getOwnPropertyDescriptor(function foo() {}, 'name');
+	if (nameDescriptor && !nameDescriptor.configurable) {
+		return _hasConfigurableName = false;
+	}
+	return _hasConfigurableName = true;
+}
+
+let _hasToStringTag: boolean;
+
+/**
+ * Detects if the runtime environment supports specifying a Symbol.toStringTag
+ */
+export function hasToStringTag(): boolean {
+	if (_hasToStringTag !== undefined) {
+		return _hasToStringTag;
+	}
+	const a: any = {};
+	a[Symbol.toStringTag] = 'foo';
+	return _hasToStringTag = (a + '') === '[object foo]';
+}

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -19,6 +19,22 @@ function hasConfigurableName(): boolean {
 	return _hasConfigurableName = true;
 }
 
+let _hasToStringTag: boolean;
+
+/**
+ * Detects if Object.prototype has a
+ */
+function hasToStringTag(): boolean {
+	if (_hasToStringTag !== undefined) {
+		return _hasToStringTag;
+	}
+	const toStringTagDescriptor = Object.getOwnPropertyDescriptor(Math, <any> Symbol.toStringTag);
+	if (toStringTagDescriptor) {
+		return _hasToStringTag = true;
+	}
+	return _hasToStringTag = false;
+}
+
 registerSuite({
 	name: 'lib/compose',
 	create: {
@@ -377,17 +393,6 @@ registerSuite({
 				foo: 'bar'
 			}).extend(composeObj);
 			assert.notStrictEqual(createFoo.prototype.constructor, constructor);
-		},
-
-		'toString property not copied'() {
-			function toString() {
-				throw new Error('Should not be copied');
-			}
-			const composeObj = { toString };
-			const createFoo = compose({
-				foo: 'bar'
-			}).extend(composeObj);
-			assert.notStrictEqual(createFoo.prototype.toString, toString);
 		},
 
 		'array prototype property': function() {
@@ -1611,8 +1616,8 @@ registerSuite({
 		},
 
 		'instance to string'(this: any) {
-			if (!hasConfigurableName()) {
-				this.skip('Functions do not have configurable names');
+			if (!hasToStringTag()) {
+				this.skip('Does not natively support Symbol.toStringTag');
 			}
 			const createFoo = compose('Foo', {});
 			const foo = createFoo();
@@ -1654,8 +1659,8 @@ registerSuite({
 		},
 
 		'unlabelled factories use "Compose"'(this: any) {
-			if (!hasConfigurableName()) {
-				this.skip('Functions do not have configurable names');
+			if (!hasToStringTag()) {
+				this.skip('Does not natively support Symbol.toStringTag');
 			}
 			const createEmpty = compose({});
 			const empty = createEmpty();
@@ -1663,8 +1668,8 @@ registerSuite({
 		},
 
 		'factories "inherit" names when not supplied'(this: any) {
-			if (!hasConfigurableName()) {
-				this.skip('Functions do not have configurable names');
+			if (!hasToStringTag()) {
+				this.skip('Does not natively support Symbol.toStringTag');
 			}
 			const createStatic = compose('Static', {})
 				.static({

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -22,17 +22,15 @@ function hasConfigurableName(): boolean {
 let _hasToStringTag: boolean;
 
 /**
- * Detects if Object.prototype has a
+ * Detects if the runtime environment supports specifying a Symbol.toStringTag
  */
 function hasToStringTag(): boolean {
 	if (_hasToStringTag !== undefined) {
 		return _hasToStringTag;
 	}
-	const toStringTagDescriptor = Object.getOwnPropertyDescriptor(Math, <any> Symbol.toStringTag);
-	if (toStringTagDescriptor) {
-		return _hasToStringTag = true;
-	}
-	return _hasToStringTag = false;
+	const a: any = {};
+	a[Symbol.toStringTag] = 'foo';
+	return _hasToStringTag = (a + '') === '[object foo]';
 }
 
 registerSuite({

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1,37 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { hasToStringTag, hasConfigurableName } from '../support/util';
 import compose, { GenericClass, ComposeMixinDescriptor, getInitFunctionNames } from '../../src/compose';
-
-let _hasConfigurableName: boolean;
-
-/**
- * Detects if functions have configurable names, some browsers that are not 100% ES2015
- * compliant do not.
- */
-function hasConfigurableName(): boolean {
-	if (_hasConfigurableName !== undefined) {
-		return _hasConfigurableName;
-	}
-	const nameDescriptor = Object.getOwnPropertyDescriptor(function foo() {}, 'name');
-	if (nameDescriptor && !nameDescriptor.configurable) {
-		return _hasConfigurableName = false;
-	}
-	return _hasConfigurableName = true;
-}
-
-let _hasToStringTag: boolean;
-
-/**
- * Detects if the runtime environment supports specifying a Symbol.toStringTag
- */
-function hasToStringTag(): boolean {
-	if (_hasToStringTag !== undefined) {
-		return _hasToStringTag;
-	}
-	const a: any = {};
-	a[Symbol.toStringTag] = 'foo';
-	return _hasToStringTag = (a + '') === '[object foo]';
-}
 
 registerSuite({
 	name: 'lib/compose',

--- a/tests/unit/mixins/createDestroyable.ts
+++ b/tests/unit/mixins/createDestroyable.ts
@@ -2,6 +2,20 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createDestroyable, { isDestroyable } from '../../../src/mixins/createDestroyable';
 
+let _hasToStringTag: boolean;
+
+/**
+ * Detects if the runtime environment supports specifying a Symbol.toStringTag
+ */
+function hasToStringTag(): boolean {
+	if (_hasToStringTag !== undefined) {
+		return _hasToStringTag;
+	}
+	const a: any = {};
+	a[Symbol.toStringTag] = 'foo';
+	return _hasToStringTag = (a + '') === '[object foo]';
+}
+
 registerSuite({
 	name: 'mixins/createDestroyable',
 	'own/destroy handle'() {
@@ -57,7 +71,10 @@ registerSuite({
 		assert.isFalse(isDestroyable(/foo/));
 		assert.isFalse(isDestroyable(() => { }));
 	},
-	'toString()'() {
+	'toString()'(this: any) {
+		if (!hasToStringTag()) {
+			this.skip('Environment doesn\'t support Symbol.toStringTag');
+		}
 		const destroyable = createDestroyable();
 		assert.strictEqual((<any> destroyable).toString(), '[object Destroyable]');
 	}

--- a/tests/unit/mixins/createDestroyable.ts
+++ b/tests/unit/mixins/createDestroyable.ts
@@ -1,20 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { hasToStringTag } from '../../support/util';
 import createDestroyable, { isDestroyable } from '../../../src/mixins/createDestroyable';
-
-let _hasToStringTag: boolean;
-
-/**
- * Detects if the runtime environment supports specifying a Symbol.toStringTag
- */
-function hasToStringTag(): boolean {
-	if (_hasToStringTag !== undefined) {
-		return _hasToStringTag;
-	}
-	const a: any = {};
-	a[Symbol.toStringTag] = 'foo';
-	return _hasToStringTag = (a + '') === '[object foo]';
-}
 
 registerSuite({
 	name: 'mixins/createDestroyable',

--- a/tests/unit/mixins/createEvented.ts
+++ b/tests/unit/mixins/createEvented.ts
@@ -2,6 +2,20 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createEvented from '../../../src/mixins/createEvented';
 
+let _hasToStringTag: boolean;
+
+/**
+ * Detects if the runtime environment supports specifying a Symbol.toStringTag
+ */
+function hasToStringTag(): boolean {
+	if (_hasToStringTag !== undefined) {
+		return _hasToStringTag;
+	}
+	const a: any = {};
+	a[Symbol.toStringTag] = 'foo';
+	return _hasToStringTag = (a + '') === '[object foo]';
+}
+
 registerSuite({
 	name: 'mixins/createEvented',
 	creation() {
@@ -210,7 +224,10 @@ registerSuite({
 			assert.deepEqual(eventStack, [ 'foo', 'bar', 'bar' ]);
 		}
 	},
-	'toString()'() {
+	'toString()'(this: any) {
+		if (!hasToStringTag()) {
+			this.skip('Environment doesn\'t support Symbol.toStringTag');
+		}
 		const evented = createEvented();
 		assert.strictEqual((<any> evented).toString(), '[object Evented]');
 	}

--- a/tests/unit/mixins/createEvented.ts
+++ b/tests/unit/mixins/createEvented.ts
@@ -1,20 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { hasToStringTag } from '../../support/util';
 import createEvented from '../../../src/mixins/createEvented';
-
-let _hasToStringTag: boolean;
-
-/**
- * Detects if the runtime environment supports specifying a Symbol.toStringTag
- */
-function hasToStringTag(): boolean {
-	if (_hasToStringTag !== undefined) {
-		return _hasToStringTag;
-	}
-	const a: any = {};
-	a[Symbol.toStringTag] = 'foo';
-	return _hasToStringTag = (a + '') === '[object foo]';
-}
 
 registerSuite({
 	name: 'mixins/createEvented',

--- a/tests/unit/mixins/createStateful.ts
+++ b/tests/unit/mixins/createStateful.ts
@@ -1,22 +1,9 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { hasToStringTag } from '../../support/util';
 import Promise from 'dojo-shim/Promise';
 import { Observable, Observer } from 'rxjs/Rx';
 import createStateful, { State } from '../../../src/mixins/createStateful';
-
-let _hasToStringTag: boolean;
-
-/**
- * Detects if the runtime environment supports specifying a Symbol.toStringTag
- */
-function hasToStringTag(): boolean {
-	if (_hasToStringTag !== undefined) {
-		return _hasToStringTag;
-	}
-	const a: any = {};
-	a[Symbol.toStringTag] = 'foo';
-	return _hasToStringTag = (a + '') === '[object foo]';
-}
 
 registerSuite({
 	name: 'mixins/createStateful',

--- a/tests/unit/mixins/createStateful.ts
+++ b/tests/unit/mixins/createStateful.ts
@@ -4,6 +4,20 @@ import Promise from 'dojo-shim/Promise';
 import { Observable, Observer } from 'rxjs/Rx';
 import createStateful, { State } from '../../../src/mixins/createStateful';
 
+let _hasToStringTag: boolean;
+
+/**
+ * Detects if the runtime environment supports specifying a Symbol.toStringTag
+ */
+function hasToStringTag(): boolean {
+	if (_hasToStringTag !== undefined) {
+		return _hasToStringTag;
+	}
+	const a: any = {};
+	a[Symbol.toStringTag] = 'foo';
+	return _hasToStringTag = (a + '') === '[object foo]';
+}
+
 registerSuite({
 	name: 'mixins/createStateful',
 	creation: {
@@ -415,7 +429,10 @@ registerSuite({
 			assert.strictEqual(count, 2, 'listener called again');
 		}
 	},
-	'toString()'() {
+	'toString()'(this: any) {
+		if (!hasToStringTag()) {
+			this.skip('Environment doesn\'t support Symbol.toStringTag');
+		}
 		const stateful: any = createStateful();
 		assert.strictEqual(stateful.toString(), '[object Stateful]');
 	}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:
- [X] There is a related issue
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR uses `Symbol.toStringTag` to provide the class name when running in a fully ES6 compatible environment.  This is much "safer" and does not interfere with anyone choosing to override/implement a `.toString()` function in a class.  It will only affect the `Object.prototype.toString()` which reads this symbol.

This is one of the [last pieces of ES6](https://kangax.github.io/compat-table/es6/#test-well-known_symbols_Symbol.toStringTag) to be widely implemented.  Currently it is only v8 and iOS 10 that are supporting this.  In other environments, logging out will `instance.toString()` will by default log out `[object Object]` instead of the class name.

Resolves #81 
