### PR TITLE
Ensure state is set before queueing the event emit

### DIFF
--- a/src/bases/createStateful.ts
+++ b/src/bases/createStateful.ts
@@ -83,9 +83,9 @@ function setStatefulState(target: Stateful<State>, state: State): void {
 	if (!previousState) {
 		throw new Error('Unable to set destroyed state');
 	}
+	const type = previousState && Object.keys(previousState).length ? 'state:changed' : 'state:initialized';
+	state = deepAssign(previousState, state);
 	queueTask(() => {
-		const type = previousState && Object.keys(previousState).length ? 'state:changed' : 'state:initialized';
-		state = deepAssign(previousState, state);
 		const eventObject = {
 			type,
 			state,

--- a/tests/unit/bases/createStateful.ts
+++ b/tests/unit/bases/createStateful.ts
@@ -396,6 +396,8 @@ registerSuite({
 				}
 			});
 
+			assert.deepEqual(stateful.state, { foo: 'foo' });
+
 			stateful.on('state:initialized', (event) => {
 				count++;
 				assert.strictEqual(event.target, stateful);

--- a/tests/unit/bases/createStateful.ts
+++ b/tests/unit/bases/createStateful.ts
@@ -7,7 +7,7 @@ import { State } from 'dojo-interfaces/bases';
 import { Observable, Observer } from 'rxjs/Rx';
 import createStateful from '../../../src/bases/createStateful';
 
-const timingDelay = delay(10);
+const timingDelay = delay(50);
 
 registerSuite({
 	name: 'mixins/createStateful',


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:
- [x] There is a related issue
- [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

There are dependencies that the state is set sync, so move the assignment outside queueing the task of the event emit.

Resolves #85
