### PR TITLE
Add override() to compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-has": ">=2.0.0-alpha.4",
-    "dojo-shim": ">=2.0.0-alpha.4",
-    "dojo-core": ">=2.0.0-alpha.12"
+    "dojo-has": ">=2.0.0-alpha.6",
+    "dojo-shim": ">=2.0.0-beta.3",
+    "dojo-core": ">=2.0.0-alpha.16"
   },
   "devDependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
-    "@types/chai": "3.4.*",
-    "@types/es6-shim": "0.0.*",
-    "@types/glob": "5.0.*",
-    "@types/grunt": "0.4.*",
-    "dojo-interfaces": "^2.0.0-alpha.1",
+    "@types/chai": "~3.4.0",
+    "@types/es6-shim": "~0.31.0",
+    "@types/glob": "~5.0.0",
+    "@types/grunt": "~0.4.0",
+    "dojo-interfaces": ">=2.0.0-alpha.4",
     "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.16",

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -604,7 +604,7 @@ function override<T, O>(baseFactory: ComposeFactory<T, O>, className: any, prope
 
 	const base = privateFactoryData.get(baseFactory).base;
 
-	/* TODO: In TypeScript 2.1 we should have `partial` types which can then be used to provide type checking at design time
+	/* TODO: In TypeScript 2.1 we have merge types which can then be used to provide type checking at design time
 	 * similiar to this */
 	Object.keys(properties).forEach((key) => {
 		if (!(key in base)) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,3 +1,4 @@
+import { deprecated } from 'dojo-core/instrument';
 import { assign } from 'dojo-core/lang';
 import { from as arrayFrom, includes } from 'dojo-shim/array';
 import WeakMap from 'dojo-shim/WeakMap';
@@ -186,6 +187,8 @@ export function getInitFunctionNames(factory: ComposeFactory<any, any>): string[
 
 /**
  * Perform an extension of a class
+ *
+ * @deprecated
  */
 const doExtend = rebase(extend);
 
@@ -193,6 +196,11 @@ const doExtend = rebase(extend);
  * Perform a mixin of a class
  */
 const doMixin = rebase(mixin);
+
+/**
+ * Perform a override of a class
+ */
+const doOverride = rebase(override);
 
 /**
  * Perform an overlay of a class
@@ -234,8 +242,9 @@ const doFactoryDescriptor = rebase(factoryDescriptor);
  * A set of functions that are used to decorate the compose factories
  */
 const staticMethods = {
-	extend: doExtend,
+	extend: doExtend, /* DEPRECATED */
 	mixin: doMixin,
+	override: doOverride,
 	overlay: doOverlay,
 	from: doFrom,
 	before: doBefore,
@@ -440,10 +449,14 @@ export interface ComposeInitializationFunction<T, O> {
 }
 
 /* Extension API */
+
+/* DEPRECATED - This API will be removed in the future */
+
 export interface ComposeFactory<T, O> extends ComposeMixinable<T, O> {
 	/**
 	 * Extend the factory prototype with the supplied object literal, class, or factory
 	 *
+	 * @deprecated
 	 * @param extension The object literal, class or factory to extend
 	 * @template T The original type of the factory
 	 * @template U The type of the extension
@@ -461,6 +474,7 @@ export interface Compose {
 	 * Extend a compose factory prototype with the supplied object literal, class, or
 	 * factory.
 	 *
+	 * @deprecated
 	 * @param base The base compose factory to extend
 	 * @param extension The object literal, class or factory that is the extension
 	 * @template T The base type of the factory
@@ -477,12 +491,14 @@ export interface Compose {
 /**
  * The internal implementation of extending a compose factory
  *
+ * @deprecated
  * @param base The base compose factory that is being extended
  * @param extension The extension to apply to the compose factory
  */
 function extend<T, O, U, P>(base: ComposeFactory<T, O>, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 function extend<T, O, U, P>(base: ComposeFactory<T, O>, className: string, extension: ComposeFactory<U, P>): ComposeFactory<T & U, O & P>;
 function extend<O>(base: ComposeFactory<any, O>, className: any, extension?: any): ComposeFactory<any, O> {
+	deprecated({ message: 'This function will be removed, use "override" instead.', name: 'extend' });
 	if (typeof className !== 'string') {
 		extension = className;
 		className = undefined;
@@ -492,6 +508,84 @@ function extend<O>(base: ComposeFactory<any, O>, className: any, extension?: any
 		className,
 		proto: typeof extension === 'function' ? extension.prototype : extension,
 		factories: [ base ]
+	});
+}
+
+/* Override API */
+
+export interface ComposeFactory<T, O> extends ComposeMixinable<T, O> {
+	/**
+	 * Override certain properties on the existing factory, returning a new factory.  If the properties
+	 * are not present in the existing factory, override will throw.
+	 *
+	 * @param properties The properties to override
+	 */
+	override(properties: any): this;
+
+	/**
+	 * Override certain properties on the existing factory, returning a new factory.  If the properties
+	 * are not present in the existing factory, override with throw.
+	 *
+	 * @param className The class name for the factory
+	 * @param properties The properties to override
+	 */
+	override(className: string, properties: any): this;
+}
+
+export interface Compose {
+	/**
+	 * Override properties on a compose factory, returning a new factory.  If the properties are not
+	 * present on the base factory, override will throw.
+	 *
+	 * @param baseFactory The base compose factory to override
+	 * @param properties The properties to override
+	 */
+	override<T, O>(baseFactory: ComposeFactory<T, O>, properties: any): ComposeFactory<T, O>;
+
+	/**
+	 * Override properties on a compose factory, returning a new factory.  If the properties are not
+	 * present on the base factory, override will throw.
+	 *
+	 * @param baseFactory The base compose factory to override
+	 * @param className The class name for the factory
+	 * @param properties The properties to override
+	 */
+	override<T, O>(baseFactory: ComposeFactory<T, O>, className: string, properties: any): ComposeFactory<T, O>;
+}
+
+/**
+ * The internal implementation of overriding properties on a compose factory
+ *
+ * @param baseFactory The base factory
+ * @param className The name of the class that will be produced by the factory
+ * @param properties The object that contains the properties to override
+ */
+function override<T, O>(baseFactory: ComposeFactory<T, O>, properties: any): ComposeFactory<T, O>;
+function override<T, O>(baseFactory: ComposeFactory<T, O>, className: string, properties: any): ComposeFactory<T, O>;
+function override<T, O>(baseFactory: ComposeFactory<T, O>, className: any, properties?: any): ComposeFactory<T, O> {
+	if (typeof className !== 'string') {
+		properties = className;
+		className = undefined;
+	}
+
+	if (typeof properties !== 'object') {
+		throw new TypeError('Argument "properties" must be an object.');
+	}
+
+	const base = privateFactoryData.get(baseFactory).base;
+
+	/* TODO: In TypeScript 2.1 we should have `partial` types which can then be used to provide type checking at design time
+	 * similiar to this */
+	Object.keys(properties).forEach((key) => {
+		if (!(key in base)) {
+			throw new TypeError(`Attempting to override missing property "${key}"`);
+		}
+	});
+
+	return createFactory({
+		className,
+		proto: properties,
+		factories: [ baseFactory ]
 	});
 }
 
@@ -1134,8 +1228,9 @@ const compose = create as Compose;
 assign(compose, {
 	create,
 	static: _static,
-	extend,
+	extend, /* DEPRECATED */
 	mixin,
+	override,
 	overlay,
 	from,
 	before,

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1038,6 +1038,19 @@ registerSuite({
 			assert.strictEqual(overrideCount, 1);
 		},
 
+		'overridding arrays'() {
+			const createFoo = compose({
+					foo: [ 'foo', 'bar' ]
+				})
+				.override({
+					foo: [ 'baz', 'qat' ]
+				});
+
+			const foo = createFoo();
+
+			assert.deepEqual(foo.foo, [ 'baz', 'qat' ], 'Array should be overidden, not merged');
+		},
+
 		'className'(this: any) {
 			if (!hasToStringTag()) {
 				this.skip('Does not natively support Symbol.toStringTag');

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1,10 +1,34 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { setWarn } from 'dojo-core/instrument';
 import { hasToStringTag, hasConfigurableName } from '../support/util';
 import compose, { GenericClass, ComposeMixinDescriptor, getInitFunctionNames } from '../../src/compose';
 
+let warnStack: any[][] = [];
+
+function getLastWarning(): string | undefined {
+	if (!warnStack.length) {
+		return;
+	}
+	const args = warnStack[warnStack.length - 1];
+	return args && args[0];
+}
+
 registerSuite({
 	name: 'lib/compose',
+
+	setup() {
+		/* change the global warning function so we don't end up with a console full of garbage */
+		setWarn(function(...args: any[]) {
+			warnStack.push(args);
+		});
+	},
+
+	teardown() {
+		/* put it back the way it was */
+		setWarn();
+	},
+
 	create: {
 		'es6 base class': function () {
 			let counter = 0;
@@ -347,7 +371,7 @@ registerSuite({
 			assert.strictEqual(foo['nonWritable'], 'constant', 'Didn\'t copy property value');
 
 			/* modules are now emitted in strict mode, which causes a throw
-			* when trying to assign to a read-only property */
+			 * when trying to assign to a read-only property */
 			assert.throws(() => {
 				foo['nonWritable'] = 'variable';
 			}, TypeError);
@@ -511,6 +535,18 @@ registerSuite({
 				assert.deepEqual(createFoo.prototype.arr, [ 'foo', 'bar' ]);
 				assert.deepEqual(createBar.prototype.arr, [ 'foo', 'bar', 'baz' ]);
 			}
+		},
+
+		'deprecated'() {
+			warnStack = [];
+			compose({}).extend({});
+
+			assert.strictEqual(getLastWarning(), 'DEPRECATED: extend: This function will be removed, use "override" instead.');
+
+			warnStack = [];
+			compose.extend(compose({}), {});
+
+			assert.strictEqual(getLastWarning(), 'DEPRECATED: extend: This function will be removed, use "override" instead.');
 		}
 	},
 	mixin: {
@@ -941,6 +977,113 @@ registerSuite({
 			}
 		}
 	},
+
+	override: {
+		'.override()'() {
+			let count = 0;
+			let overrideCount = 0;
+
+			const createFoo = compose.create({
+				foo() {
+					count++;
+				}
+			});
+
+			const createOverideFoo = compose.override(createFoo, {
+				foo() {
+					overrideCount++;
+				}
+			});
+
+			const foo = createFoo();
+			const overrideFoo = createOverideFoo();
+
+			assert.strictEqual(count, 0);
+			assert.strictEqual(overrideCount, 0);
+
+			foo.foo();
+
+			assert.strictEqual(count, 1);
+			assert.strictEqual(overrideCount, 0);
+
+			overrideFoo.foo();
+
+			assert.strictEqual(count, 1);
+			assert.strictEqual(overrideCount, 1);
+		},
+
+		'chaining'() {
+			let count = 0;
+			let overrideCount = 0;
+
+			const createFoo = compose({
+					foo() {
+						count++;
+					}
+				})
+				.override({
+					foo() {
+						overrideCount++;
+					}
+				});
+
+			const foo = createFoo();
+
+			assert.strictEqual(count, 0);
+			assert.strictEqual(overrideCount, 0);
+
+			foo.foo();
+
+			assert.strictEqual(count, 0);
+			assert.strictEqual(overrideCount, 1);
+		},
+
+		'className'(this: any) {
+			if (!hasToStringTag()) {
+				this.skip('Does not natively support Symbol.toStringTag');
+			}
+
+			const createFoo = compose('Foo', {
+					foo() { }
+				})
+				.override('Bar', {
+					foo() { }
+				});
+
+			const foo = createFoo();
+			assert.strictEqual((<any> foo).toString(), '[object Bar]');
+		},
+
+		'not passing object as properties'() {
+			const createFoo = compose({
+				foo() { }
+			});
+
+			assert.throws(() => {
+				createFoo.override('Foo');
+			}, TypeError, 'Argument "properties" must be an object.');
+
+			assert.throws(() => {
+				createFoo.override(function () {
+					return 'foo';
+				});
+			}, TypeError, 'Argument "properties" must be an object.');
+		},
+
+		'missing property in baseFactory'() {
+			const createFoo = compose({
+				foo () { }
+			});
+
+			assert.throws(() => {
+				createFoo.override({
+					foo() { },
+					bar: 2
+				});
+			}, TypeError, 'Attempting to override missing property "bar"');
+		}
+	},
+
 	overlay: {
 		'.overlay()': function () {
 			let count = 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR deprecates `compose.extend()` and introduces `compose.override()`.

Now whenever `.extend()` is called, it will log a warning that indicates that the API is deprecated and will be removed in the future.  Plus all the JSDOC has been updated to reflect the deprecated nature of the API.

`.override()` takes an object of properties that will override the values of the underlying factory prototype.  `.override()` does not augment the underlying class type that is constructed by the factory.  Like all other compose functions `.override()` will return a new instance of the factory.  Also, if there is a property in the `properties` argument that is not part of the factory class that is being overridden, `.override()` will throw.

It is expected in TypeScript 2.1 and `partial` types, that we will be able to guard at design time, that `properties` can only contain valid properties of the appropriate types to be mixed into the new class.

Resolves #84 
