### PR TITLE
Expose `stateFrom` from as a readonly property of `Stateful`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/typings/dist/
 .baseDir.ts
 html-report
 coverage-unmapped.json
+yarn.lock

--- a/src/bases/createStateful.ts
+++ b/src/bases/createStateful.ts
@@ -109,7 +109,6 @@ const createStateful: StatefulFactory = createEvented
 				if (observedState) {
 					return observedState.observable;
 				}
-				return undefined;
 			},
 
 			get state(this: Stateful<State>): State {

--- a/src/bases/createStateful.ts
+++ b/src/bases/createStateful.ts
@@ -104,6 +104,14 @@ const createStateful: StatefulFactory = createEvented
 	.mixin({
 		className: 'Stateful',
 		mixin: {
+			get stateFrom(this: Stateful<State>): ObservableState<State> | undefined {
+				const observedState = observedStateMap.get(this);
+				if (observedState) {
+					return observedState.observable;
+				}
+				return undefined;
+			},
+
 			get state(this: Stateful<State>): State {
 				return stateWeakMap.get(this);
 			},

--- a/tests/unit/bases/createStateful.ts
+++ b/tests/unit/bases/createStateful.ts
@@ -11,6 +11,7 @@ registerSuite({
 	creation: {
 		'no options'() {
 			const stateful = createStateful();
+			assert.isUndefined(stateful.stateFrom);
 			assert.deepEqual(stateful.state, {}, 'stateful should have empty state');
 			assert.isFunction(stateful.setState, 'stateful should have `setState` function');
 		},
@@ -42,6 +43,7 @@ registerSuite({
 			});
 
 			assert.strictEqual(called, 1);
+			assert.equal(stateful.stateFrom, observer);
 			assert.deepEqual(stateful.state, { foo: 'bar' });
 		},
 		'with id of 0'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Expose `getter` for `stateFrom` within `createStateful`, depends on release of `dojo-interfaces`

Supersedes https://github.com/dojo/widgets/pull/122

Resolves #https://github.com/dojo/widgets/issues/121
