### PR TITLE
Add wildcards support in event type name.

### DIFF
--- a/src/bases/createEvented.ts
+++ b/src/bases/createEvented.ts
@@ -31,6 +31,11 @@ export interface EventedFactory extends ComposeFactory<Evented, EventedOptions> 
 const listenersMap = new WeakMap<Evented, EventedCallbackMap>();
 
 /**
+ * A map that contains event type names that contain wildcards and their RegExp mapping
+ */
+const regexMap = new Map<string, RegExp>();
+
+/**
  * A guard which determines if the value is `Actionable`
  *
  * @param value The value to guard against
@@ -71,15 +76,20 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
  */
 
 function isGlobMatch(globString: string, targetString: string): boolean {
-	if (!globString || !targetString) {
-		return false;
-	}
-	const regex = new RegExp(`^${ globString.replace(/\*/g, '.*') }$`);
+	if (globString.indexOf('*') !== -1) {
+		let regex: RegExp;
+		if (regexMap.has(globString)) {
+			regex = regexMap.get(globString)!;
+		}
+		else {
+			regex = new RegExp(`^${ globString.replace(/\*/g, '.*') }$`);
+			regexMap.set(globString, regex);
+		}
+		return regex.test(targetString);
 
-	if (regex.test(targetString)) {
-		return true;
+	} else {
+		return globString === targetString;
 	}
-	return false;
 }
 
 /**

--- a/tests/unit/bases/createEvented.ts
+++ b/tests/unit/bases/createEvented.ts
@@ -175,6 +175,77 @@ registerSuite({
 			}, TypeError);
 		}
 	},
+	'wildcards in event type name': {
+		'all event types'() {
+			const eventStack: string[] = [];
+			const evented = createEvented();
+			evented.on('*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'bar', 'foo:bar' ]);
+		},
+		'event types starting with a pattern'() {
+			const eventStack: string[] = [];
+			const evented = createEvented();
+			evented.on('foo:*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foo:' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ 'foo:', 'foo:bar' ]);
+		},
+		'event types ending with a pattern'() {
+			const eventStack: string[] = [];
+			const evented = createEvented();
+			evented.on('*:bar', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: ':bar' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ ':bar', 'foo:bar' ]);
+		},
+		'event types contains a pattern'() {
+			const eventStack: string[] = [];
+			const evented = createEvented();
+			evented.on('*foo*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foobar' });
+			evented.emit({ type: 'barfoo' });
+			evented.emit({ type: 'barfoobiz' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'foobar', 'barfoo', 'barfoobiz' ]);
+		},
+		'multiple matches'() {
+			const eventStack: string[] = [];
+			const evented = createEvented();
+			evented.on('foo', (event) => {
+				eventStack.push(`foo->${event.type}`);
+			});
+			evented.on('*foo', (event) => {
+				eventStack.push(`*foo->${event.type}`);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foobar' });
+			evented.emit({ type: 'barfoo' });
+
+			assert.deepEqual(eventStack, [ 'foo->foo', '*foo->foo', '*foo->barfoo' ]);
+		}
+	},
 	'actions': {
 		'listener'() {
 			const eventStack: string[] = [];


### PR DESCRIPTION
**Type:** Enhancement

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds wildcards support in event type name.

Note: Due to limited use cases in event type name, currently only `*` that matches 0 or more characters is supported.

Resolves #98 
