### PR TITLE
Remove Android test env from intern-saucelabs

### DIFF
--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -6,7 +6,7 @@ export const environments = [
 	{ browserName: 'firefox', version: '43', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
-	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' },
+	/*{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' },*/
 	{ browserName: 'iphone', version: '9.1', deviceName: 'iPhone 6' }
 ];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The units tests are failing due to a travis environmental issue for Android, so commenting out until this has been resolved.