### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dojo-compose
+# @dojo/compose
 
 [![Build Status](https://travis-ci.org/dojo/compose.svg?branch=master)](https://travis-ci.org/dojo/compose)
 [![codecov.io](http://codecov.io/github/dojo/compose/coverage.svg?branch=master)](http://codecov.io/github/dojo/compose?branch=master)
-[![npm version](https://badge.fury.io/js/dojo-compose.svg)](http://badge.fury.io/js/dojo-compose)
+[![npm version](https://badge.fury.io/js/@dojo/compose.svg)](http://badge.fury.io/js/@dojo/compose)
 
 A composition library, which works well in a TypeScript environment.
 
@@ -33,7 +33,7 @@ The `compose` module's default export is a function which creates classes.  This
 If you want to create a new class via a prototype and create an instance of it, you would want to do something like this:
 
 ```typescript
-import compose from 'dojo-compose/compose';
+import compose from '@dojo/compose/compose';
 
 const fooFactory = compose({
 	foo: function () {
@@ -49,7 +49,7 @@ const foo = fooFactory();
 If you want to create a new class via an ES6/TypeScript class and create an instance of it, you would want to do something like this:
 
 ```typescript
-import compose from 'dojo-compose/compose';
+import compose from '@dojo/compose/compose';
 
 class Foo {
 	foo() {
@@ -67,7 +67,7 @@ const foo = fooFactory();
 You can also subclass:
 
 ```typescript
-import compose from 'dojo-compose/compose';
+import compose from '@dojo/compose/compose';
 
 const fooFactory = compose({
 	foo: function () {
@@ -87,7 +87,7 @@ const foo = myFooFactory();
 During creation, `compose` takes a second optional argument, which is an initializer function.  The constructor pattern for all `compose` classes is to take an optional `options` argument.  Therefore the initialization function should take this optional argument:
 
 ```typescript
-import compose from 'dojo-compose/compose';
+import compose from '@dojo/compose/compose';
 
 interface FooOptions {
 	foo?: Function,
@@ -459,15 +459,15 @@ to the 'final' factory in a chain.
 The easiest way to use this package is to install it via `npm`:
 
 ```
-$ npm install dojo-compose
+$ npm install @dojo/compose
 ```
 
 In addition, you can clone this repository and use the Grunt build scripts to manage the package.
 
-Using under TypeScript or ES6 modules, you would generally want to just `import` the `dojo-compose/compose` module:
+Using under TypeScript or ES6 modules, you would generally want to just `import` the `@dojo/compose/compose` module:
 
 ```typescript
-import compose from 'dojo-compose/compose';
+import compose from '@dojo/compose/compose';
 
 const createFoo = compose({
 	foo: 'foo'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-compose",
+  "name": "@dojo/compose",
   "version": "2.0.0-pre",
   "description": "A composition library, which works well in a TypeScript environment.",
   "homepage": "http://dojotoolkit.org",
@@ -18,16 +18,16 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-has": ">=2.0.0-alpha.6",
-    "dojo-shim": ">=2.0.0-beta.3",
-    "dojo-core": ">=2.0.0-alpha.16"
+    "@dojo/has": "2.0.0-alpha.7",
+    "@dojo/shim": "2.0.0-beta.8",
+    "@dojo/core": "2.0.0-alpha.19"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
-    "dojo-interfaces": ">=2.0.0-alpha.7",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.8",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.21",
     "intern": "~3.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.21",
     "intern": "~3.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.8",
-    "@dojo/core": "2.0.0-alpha.19"
+    "@dojo/core": "2.0.0-alpha.20"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,4 +1,4 @@
-import WeakMap from 'dojo-shim/WeakMap';
+import WeakMap from '@dojo/shim/WeakMap';
 
 export interface AdvisingFunction extends Function {
 	/**

--- a/src/bases/createCancelableEvent.ts
+++ b/src/bases/createCancelableEvent.ts
@@ -1,4 +1,4 @@
-import { EventCancelableObject } from 'dojo-interfaces/core';
+import { EventCancelableObject } from '@dojo/interfaces/core';
 
 /**
  * A simple factory that creates an event object which can be cancelled

--- a/src/bases/createDestroyable.ts
+++ b/src/bases/createDestroyable.ts
@@ -1,7 +1,7 @@
-import { Destroyable } from 'dojo-interfaces/bases';
-import { Handle } from 'dojo-interfaces/core';
-import Promise from 'dojo-shim/Promise';
-import WeakMap from 'dojo-shim/WeakMap';
+import { Destroyable } from '@dojo/interfaces/bases';
+import { Handle } from '@dojo/interfaces/core';
+import Promise from '@dojo/shim/Promise';
+import WeakMap from '@dojo/shim/WeakMap';
 import compose, { ComposeFactory } from '../compose';
 
 export interface DestroyableFactory extends ComposeFactory<Destroyable, {}> { }

--- a/src/bases/createEvented.ts
+++ b/src/bases/createEvented.ts
@@ -1,9 +1,9 @@
-import { on } from 'dojo-core/aspect';
+import { on } from '@dojo/core/aspect';
 import {
 	EventObject,
 	EventTargettedObject,
 	Handle
-} from 'dojo-interfaces/core';
+} from '@dojo/interfaces/core';
 import {
 	Evented,
 	EventedOptions,
@@ -11,10 +11,10 @@ import {
 	EventedListenerOrArray,
 	EventedListenersMap,
 	EventedCallback
-} from 'dojo-interfaces/bases';
-import { Actionable } from 'dojo-interfaces/abilities';
-import Map from 'dojo-shim/Map';
-import WeakMap from 'dojo-shim/WeakMap';
+} from '@dojo/interfaces/bases';
+import { Actionable } from '@dojo/interfaces/abilities';
+import Map from '@dojo/shim/Map';
+import WeakMap from '@dojo/shim/WeakMap';
 import { ComposeFactory } from '../compose';
 import createDestroyable from './createDestroyable';
 

--- a/src/bases/createStateful.ts
+++ b/src/bases/createStateful.ts
@@ -1,11 +1,11 @@
-import { deepAssign } from 'dojo-core/lang';
+import { deepAssign } from '@dojo/core/lang';
 import {
 	State,
 	Stateful,
 	StatefulMixin,
 	StatefulOptions
-} from 'dojo-interfaces/bases';
-import WeakMap from 'dojo-shim/WeakMap';
+} from '@dojo/interfaces/bases';
+import WeakMap from '@dojo/shim/WeakMap';
 import createEvented from './createEvented';
 import { ComposeFactory } from '../compose';
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,8 +1,8 @@
-import { deprecated } from 'dojo-core/instrument';
-import { assign } from 'dojo-core/lang';
-import { from as arrayFrom, includes } from 'dojo-shim/array';
-import WeakMap from 'dojo-shim/WeakMap';
-import Symbol from 'dojo-shim/Symbol';
+import { deprecated } from '@dojo/core/instrument';
+import { assign } from '@dojo/core/lang';
+import { from as arrayFrom, includes } from '@dojo/shim/array';
+import WeakMap from '@dojo/shim/WeakMap';
+import Symbol from '@dojo/shim/Symbol';
 import {
 	before as aspectBefore,
 	after as aspectAfter,

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-compose',
+	name: '@dojo/compose',
 	fixSessionCapabilities: false
 };
 
@@ -44,8 +44,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
@@ -55,9 +55,9 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
-		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
-		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
+		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
+		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
 		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
 	]
 };

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -55,9 +55,7 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
-		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
-		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
+		{ name: '@dojo', location: 'node_modules/@dojo' },
 		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
 	]
 };

--- a/tests/unit/bases/createStateful.ts
+++ b/tests/unit/bases/createStateful.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createStateful from '../../../src/bases/createStateful';
-import { Stateful, State } from 'dojo-interfaces/bases';
+import { Stateful, State } from '@dojo/interfaces/bases';
 
 registerSuite({
 	name: 'mixins/createStateful',

--- a/tests/unit/compose.ts
+++ b/tests/unit/compose.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { setWarn } from 'dojo-core/instrument';
+import { setWarn } from '@dojo/core/instrument';
 import { hasToStringTag, hasConfigurableName } from '../support/util';
 import compose, { GenericClass, ComposeMixinDescriptor, getInitFunctionNames } from '../../src/compose';
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129