### PR TITLE
Remove symbol-shim typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,20 +18,20 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/has": "2.0.0-alpha.7",
-    "@dojo/shim": "2.0.0-beta.8",
-    "@dojo/core": "2.0.0-alpha.20"
+    "@dojo/core": "2.0.0-alpha.25",
+    "@dojo/has": "2.0.0-alpha.8",
+    "@dojo/shim": "2.0.0-beta.10"
   },
   "devDependencies": {
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.9",
     "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
-    "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
-    "grunt-dojo2": ">=2.0.0-beta.21",
+    "grunt-dojo2": ">=2.0.0-beta.33",
     "intern": "~3.4.1",
     "tslint": "^3.15.1",
-    "typescript": "~2.1.4"
+    "typescript": "~2.2.1"
   }
 }

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,4 +1,3 @@
-import 'intern';
 import './aspect';
 import './compose';
 import './main';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
-	"version": "2.1.5",
 	"compilerOptions": {
 		"declaration": false,
+		"lib": [
+			"dom",
+			"es5",
+			"es2015.iterable",
+			"es2015.symbol",
+			"es2015.symbol.wellknown"
+		],
 		"module": "umd",
 		"moduleResolution": "node",
 		"noImplicitAny": true,
@@ -10,7 +16,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"strictNullChecks": true,
-		"target": "es5"
+		"target": "es5",
+		"types": [ "intern" ]
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,0 @@
-{
-	"name": "dojo-compose",
-	"globalDependencies": {
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
-	},
-	"globalDevDependencies": {
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
-	}
-}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Remove dependency on symbol shim typings, requires https://github.com/dojo/core/pull/294 to be released.

Related to https://github.com/dojo/meta/issues/113